### PR TITLE
Add OSC authors to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - scripts
 
 # Gems
 plugins:
@@ -30,9 +31,139 @@ plugins:
 
 # Authors
 authors:
-  "Jeff Geerling":
+  98faithca:
+    name: 98faithCA
+  abrar-arshad:
+    name: abrar.arshad
+  activprayer:
+    name: activprayer
+  akavlie:
+    name: akavlie
+  allencch:
+    name: allencch
+  archstl:
+    name: archstl
+  arkanabar:
+    name: arkanabar
+  auger:
+    name: auger
+  balleyne:
+    name: balleyne
+  barbarakb:
+    name: BarbaraKB
+  cade-one:
+    name: Cade_One
+  carson-weber:
+    name: Carson Weber
+  catholicschoolwebdesign:
+    name: catholicschoolwebdesign
+  catholicservant:
+    name: catholicservant
+  cjamesrun:
+    name: cjamesrun
+  davidmcafee:
+    name: davidmcafee
+  denise205:
+    name: Denise205
+  dr-peter-howard:
+    name: Dr Peter Howard
+  fatherjosephlee:
+    name: fatherjosephlee
+  geerlingguy:
     name: Jeff Geerling
     email: geerlingguy@mac.com
     web: http://www.jeffgeerling.com/
     twitter: geerlingguy
     github: geerlingguy
+  gnw-paul:
+    name: GNW_Paul
+  hughmacken:
+    name: hughmacken
+  iloveitaly:
+    name: iloveitaly
+  inspiredangela:
+    name: inspiredangela
+  jamesbergin:
+    name: jamesbergin
+  jdzondo:
+    name: jdzondo
+  jeffrey-pinyan-praying-the-mass:
+    name: Jeffrey Pinyan - Praying the Mass
+  jm0rr0w:
+    name: jm0rr0w
+  jmadrone:
+    name: jmadrone
+  jmgrenda:
+    name: JMGrenda
+  jmmr:
+    name: JMMR
+  jnichols886:
+    name: jnichols886
+  joaomachado:
+    name: JoaoMachado
+  joel-stein:
+    name: Joel Stein
+  johnfitzgerald:
+    name: JohnFitzgerald
+  jonathan-henderson:
+    name: jonathan.henderson
+  jr-duboc:
+    name: jr.duboc
+  jsignal:
+    name: jsignal
+  krisk:
+    name: krisk
+  kyle:
+    name: kyle
+  liangjh:
+    name: liangjh
+  lindamicciche:
+    name: lindamicciche
+  lurgid:
+    name: Lurgid
+  lutra:
+    name: lutra
+  mairtin:
+    name: mairtin
+  mark-skender:
+    name: Mark Skender
+  matt-k:
+    name: Matt K
+  matthew-west:
+    name: matthew-west
+  mbetit:
+    name: mbetit
+  mdhoerr:
+    name: mdhoerr
+  michael-sullivan:
+    name: Michael.Sullivan
+  mpschneiderlc:
+    name: MPSchneiderLC
+  murdaugh:
+    name: murdaugh
+  nobis-media:
+    name: Nobis Media
+  onebillionstories-com:
+    name: OneBillionStories.com
+  petros-media:
+    name: Petros Media
+  pistos:
+    name: Pistos
+  reckshow:
+    name: reckshow
+  rjzaar:
+    name: rjzaar
+  steely:
+    name: Steely
+  stmaryscoltsneck:
+    name: stmaryscoltsneck
+  trevor-james:
+    name: trevor.james
+  valerie-shpak:
+    name: Valerie Shpak
+  vicmortelmans:
+    name: vicmortelmans
+  whack:
+    name: Whack
+  youshaa:
+    name: Youshaa

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,12 @@
 ---
 layout: default
 ---
+{% assign author = site.authors[page.author] %}
 <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ author.name }}</span></span>{% endif %}</p>
   </header>
 
   <div class="post-content" itemprop="articleBody">

--- a/_posts/2009-06-26-open-source-catholic-what-is-it.md
+++ b/_posts/2009-06-26-open-source-catholic-what-is-it.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic - What is it?
-author: Jeff Geerling
+author: geerlingguy
 nid: 2
 redirect_from: /content/open-source-catholic-what-it/
 created: 1246057116

--- a/_posts/2009-06-27-building-open-source-catholic.md
+++ b/_posts/2009-06-27-building-open-source-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Building Open Source Catholic
-author: Jeff Geerling
+author: geerlingguy
 nid: 3
 comments: true
 redirect_from: /blog/oscatholic/building-open-source-catholic/

--- a/_posts/2009-06-27-podcasting-some-ideas.md
+++ b/_posts/2009-06-27-podcasting-some-ideas.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Podcasting: Some Ideas...'
-author: Jeff Geerling
+author: geerlingguy
 nid: 5
 comments: true
 redirect_from: /content/podcasting-some-ideas/

--- a/_posts/2009-06-27-the-story-of-lolsaints.md
+++ b/_posts/2009-06-27-the-story-of-lolsaints.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Story of LOLSaints
-author: Jeff Geerling
+author: geerlingguy
 nid: 162
 comments: true
 redirect_from: /blog/geerlingguy/story-lolsaints/

--- a/_posts/2009-06-28-osc-logo-ideas.md
+++ b/_posts/2009-06-28-osc-logo-ideas.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OSC Logo Ideas?
-author: Jeff Geerling
+author: geerlingguy
 nid: 11
 comments: true
 redirect_from: /forum/topics/11/

--- a/_posts/2009-06-28-why-osc-looks-different-in-explorer.md
+++ b/_posts/2009-06-28-why-osc-looks-different-in-explorer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Why OSC Looks Different in Explorer
-author: Jeff Geerling
+author: geerlingguy
 nid: 10
 comments: true
 redirect_from: /blog/oscatholic/why-osc-looks-different-explorer/

--- a/_posts/2009-06-29-being-christ-to-the-un-evangelized-at-mass.md
+++ b/_posts/2009-06-29-being-christ-to-the-un-evangelized-at-mass.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Being Christ to the un -Evangelized at Mass
-author: GNW_Paul
+author: gnw-paul
 nid: 14
 comments: true
 redirect_from: /forum/topics/14/

--- a/_posts/2009-06-29-how-to-use-this-forum.md
+++ b/_posts/2009-06-29-how-to-use-this-forum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to Use this Forum
-author: Jeff Geerling
+author: geerlingguy
 nid: 15
 comments: true
 redirect_from: /forum/topics/15/

--- a/_posts/2009-06-29-how-will-my-son-read-news-in-the-future.md
+++ b/_posts/2009-06-29-how-will-my-son-read-news-in-the-future.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How will my son read news in the future?
-author: BarbaraKB
+author: barbarakb
 nid: 23
 comments: true
 redirect_from: /blog/barbarakb/how-will-my-son-read-news-future/

--- a/_posts/2009-06-29-ideas-for-articles-on-osc.md
+++ b/_posts/2009-06-29-ideas-for-articles-on-osc.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ideas for Articles on OSC
-author: Jeff Geerling
+author: geerlingguy
 nid: 12
 comments: true
 redirect_from: /forum/topics/12/

--- a/_posts/2009-06-29-to-do-list-for-reference.md
+++ b/_posts/2009-06-29-to-do-list-for-reference.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: To-Do List (for Reference)
-author: Jeff Geerling
+author: geerlingguy
 nid: 13
 comments: true
 redirect_from: /forum/topics/13/

--- a/_posts/2009-06-30-css-buttons.md
+++ b/_posts/2009-06-30-css-buttons.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Css Buttons
-author: Whack
+author: whack
 nid: 27
 comments: true
 redirect_from: /forum/topics/27/

--- a/_posts/2009-06-30-open-source-catholic-theme-released-to-drupal-org.md
+++ b/_posts/2009-06-30-open-source-catholic-theme-released-to-drupal-org.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic Theme Released to Drupal.org
-author: Jeff Geerling
+author: geerlingguy
 nid: 30
 comments: true
 redirect_from: /content/open-source-catholic-theme-released-drupalorg/

--- a/_posts/2009-06-30-seems-a-little-funky-social-networks-description.md
+++ b/_posts/2009-06-30-seems-a-little-funky-social-networks-description.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Seems a little funky (social networks description)
-author: Whack
+author: whack
 nid: 24
 comments: true
 redirect_from: /forum/topics/24/

--- a/_posts/2009-06-30-tridentine-mass.md
+++ b/_posts/2009-06-30-tridentine-mass.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tridentine Mass?
-author: Whack
+author: whack
 nid: 26
 comments: true
 redirect_from: /forum/topics/26/

--- a/_posts/2009-07-02-wysiwyg.md
+++ b/_posts/2009-07-02-wysiwyg.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: WYSIWYG
-author: Jeff Geerling
+author: geerlingguy
 nid: 38
 comments: true
 redirect_from: /forum/topics/38/

--- a/_posts/2009-07-03-one-week-in-happy-4th.md
+++ b/_posts/2009-07-03-one-week-in-happy-4th.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: One Week in... Happy 4th!
-author: Jeff Geerling
+author: geerlingguy
 nid: 39
 comments: true
 redirect_from: /blog/oscatholic/one-week-happy-4th/

--- a/_posts/2009-07-09-cant-line-up-pictures-properly-in-css.md
+++ b/_posts/2009-07-09-cant-line-up-pictures-properly-in-css.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Can't line up pictures properly in css?
-author: Whack
+author: whack
 nid: 42
 comments: true
 redirect_from: /forum/topics/42/

--- a/_posts/2009-07-10-live-blogging-steubenville-2009.md
+++ b/_posts/2009-07-10-live-blogging-steubenville-2009.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Live-Blogging Steubenville 2009
-author: Jeff Geerling
+author: geerlingguy
 nid: 43
 comments: true
 redirect_from: /blog/oscatholic/live-blogging-steubenville-2009/

--- a/_posts/2009-07-11-wordpress-vs-drupal.md
+++ b/_posts/2009-07-11-wordpress-vs-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: WordPress vs. Drupal
-author: Cade_One
+author: cade-one
 nid: 44
 comments: true
 redirect_from: /forum/topics/44/

--- a/_posts/2009-07-13-priests-and-new-social-media.md
+++ b/_posts/2009-07-13-priests-and-new-social-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Priests and New/Social Media
-author: Jeff Geerling
+author: geerlingguy
 nid: 46
 comments: true
 redirect_from: /blog/oscatholic/priests-and-newsocial-media/

--- a/_posts/2009-07-14-how-to-make-tweet-this-or-post-to-facebook-links.md
+++ b/_posts/2009-07-14-how-to-make-tweet-this-or-post-to-facebook-links.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to make "Tweet This" or "Post to Facebook" links
-author: Jeff Geerling
+author: geerlingguy
 nid: 159
 comments: true
 redirect_from: /blog/geerlingguy/how-make-tweet-or-post-/

--- a/_posts/2009-07-14-mining-the-catechism-with-perl.md
+++ b/_posts/2009-07-14-mining-the-catechism-with-perl.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mining the Catechism with Perl
-author: Jeffrey Pinyan - Praying the Mass
+author: jeffrey-pinyan-praying-the-mass
 nid: 50
 comments: true
 redirect_from: /blog/praying-mass/mining-catechism-perl/

--- a/_posts/2009-07-16-u-s-archdioceses-and-dioceses-on-twitter.md
+++ b/_posts/2009-07-16-u-s-archdioceses-and-dioceses-on-twitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: U.S. Archdioceses and Dioceses on Twitter
-author: Jeff Geerling
+author: geerlingguy
 nid: 54
 comments: true
 redirect_from: /blog/geerlingguy/us-archdioceses-and-dioceses-twit/

--- a/_posts/2009-07-20-favorite-blogs.md
+++ b/_posts/2009-07-20-favorite-blogs.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Favorite blogs
-author: Matt K
+author: matt-k
 nid: 58
 comments: true
 redirect_from: /forum/topics/58/

--- a/_posts/2009-07-21-a-call-to-software-developers.md
+++ b/_posts/2009-07-21-a-call-to-software-developers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: A Call to Software Developers
-author: Jeff Geerling
+author: geerlingguy
 nid: 60
 comments: true
 redirect_from: /blog/oscatholic/call-software-developers/

--- a/_posts/2009-07-21-looking-for-work-in-north-west-ohio.md
+++ b/_posts/2009-07-21-looking-for-work-in-north-west-ohio.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Looking for work in North-West Ohio
-author: Cade_One
+author: cade-one
 nid: 62
 comments: true
 redirect_from: /forum/topics/62/

--- a/_posts/2009-07-21-masstimes-org-parish-sacramental-information-online.md
+++ b/_posts/2009-07-21-masstimes-org-parish-sacramental-information-online.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: MassTimes.org - Parish Sacramental Information Online
-author: Matt K
+author: matt-k
 nid: 61
 comments: true
 redirect_from: /forum/topics/61/

--- a/_posts/2009-07-23-perl.md
+++ b/_posts/2009-07-23-perl.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Perl
-author: Matt K
+author: matt-k
 nid: 64
 comments: true
 redirect_from: /forum/topics/64/

--- a/_posts/2009-07-24-ancient-faith-radio.md
+++ b/_posts/2009-07-24-ancient-faith-radio.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ancient Faith Radio
-author: Matt K
+author: matt-k
 nid: 67
 comments: true
 redirect_from: /forum/topics/67/

--- a/_posts/2009-07-24-breadcrumb-navigation.md
+++ b/_posts/2009-07-24-breadcrumb-navigation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Breadcrumb Navigation
-author: Denise205
+author: denise205
 nid: 66
 comments: true
 redirect_from: /forum/topics/66/

--- a/_posts/2009-07-24-caching-a-page-saving-a-server.md
+++ b/_posts/2009-07-24-caching-a-page-saving-a-server.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Caching a Page; Saving a Server
-author: Jeff Geerling
+author: geerlingguy
 nid: 158
 comments: true
 redirect_from: /blog/geerlingguy/caching-page-saving-server/

--- a/_posts/2009-07-25-configuring-cron-jobs-in-drupal.md
+++ b/_posts/2009-07-25-configuring-cron-jobs-in-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Configuring cron jobs in Drupal
-author: Cade_One
+author: cade-one
 nid: 69
 comments: true
 redirect_from: /forum/topics/69/

--- a/_posts/2009-07-26-the-good-warriors-of-the-net-ip-for-peace.md
+++ b/_posts/2009-07-26-the-good-warriors-of-the-net-ip-for-peace.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Good Warriors of the Net - IP for Peace!
-author: Jeff Geerling
+author: geerlingguy
 nid: 70
 comments: true
 redirect_from: /blog/oscatholic/good-warriors-net-ip-peace/

--- a/_posts/2009-07-28-acquia-to-fund-8-million-for-drupal-development.md
+++ b/_posts/2009-07-28-acquia-to-fund-8-million-for-drupal-development.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Acquia to fund $8 Million for Drupal development
-author: Matt K
+author: matt-k
 nid: 76
 comments: true
 redirect_from: /forum/topics/76/

--- a/_posts/2009-07-28-friars-of-the-immaculate.md
+++ b/_posts/2009-07-28-friars-of-the-immaculate.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Friars of the Immaculate
-author: Matt K
+author: matt-k
 nid: 77
 comments: true
 redirect_from: /blog/matt-k/friars-immaculate/

--- a/_posts/2009-07-28-great-article-on-how-twitter-corp-was-hacked.md
+++ b/_posts/2009-07-28-great-article-on-how-twitter-corp-was-hacked.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Great article on how Twitter Corp was hacked
-author: Matt K
+author: matt-k
 nid: 75
 comments: true
 redirect_from: /forum/topics/75/

--- a/_posts/2009-07-29-looking-for-drupal-joomla-cms-developers.md
+++ b/_posts/2009-07-29-looking-for-drupal-joomla-cms-developers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Looking for Drupal / Joomla / CMS Developers
-author: Jeff Geerling
+author: geerlingguy
 nid: 78
 comments: true
 redirect_from: /content/looking-drupal-joomla-cms-developers/

--- a/_posts/2009-07-30-catholictuner-com.md
+++ b/_posts/2009-07-30-catholictuner-com.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholictuner.com
-author: JoaoMachado
+author: joaomachado
 nid: 79
 comments: true
 redirect_from: /forum/topics/79/

--- a/_posts/2009-07-30-diocesan-newspapers.md
+++ b/_posts/2009-07-30-diocesan-newspapers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Diocesan newspapers
-author: Matt K
+author: matt-k
 nid: 82
 comments: true
 redirect_from: /forum/topics/82/

--- a/_posts/2009-07-30-new-forum-added-traditional-media.md
+++ b/_posts/2009-07-30-new-forum-added-traditional-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'New Forum Added: "Traditional Media"'
-author: Jeff Geerling
+author: geerlingguy
 nid: 80
 comments: true
 redirect_from: /content/new-forum-added-traditional-media/

--- a/_posts/2009-07-30-public-domain-catholic-bibles.md
+++ b/_posts/2009-07-30-public-domain-catholic-bibles.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Public Domain Catholic Bibles
-author: JoaoMachado
+author: joaomachado
 nid: 84
 comments: true
 redirect_from: /forum/topics/84/

--- a/_posts/2009-07-30-your-last-meal.md
+++ b/_posts/2009-07-30-your-last-meal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Your Last Meal
-author: Cade_One
+author: cade-one
 nid: 83
 comments: true
 redirect_from: /forum/topics/83/

--- a/_posts/2009-08-02-chat-irc.md
+++ b/_posts/2009-08-02-chat-irc.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Chat?  IRC?
-author: Pistos
+author: pistos
 nid: 87
 comments: true
 redirect_from: /forum/topics/87/

--- a/_posts/2009-08-02-new-users-introduce-yourself.md
+++ b/_posts/2009-08-02-new-users-introduce-yourself.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'New Users: Introduce yourself  :)'
-author: Pistos
+author: pistos
 nid: 86
 comments: true
 redirect_from: /forum/topics/86/

--- a/_posts/2009-08-02-opendns.md
+++ b/_posts/2009-08-02-opendns.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OpenDNS
-author: JoaoMachado
+author: joaomachado
 nid: 89
 comments: true
 redirect_from: /forum/topics/89/

--- a/_posts/2009-08-02-openpublish-a-solution-for-newspapers-wanting-to-go-digital.md
+++ b/_posts/2009-08-02-openpublish-a-solution-for-newspapers-wanting-to-go-digital.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OpenPublish - A solution for newspapers wanting to go Digital
-author: Jeff Geerling
+author: geerlingguy
 nid: 90
 comments: true
 redirect_from: /forum/topics/90/

--- a/_posts/2009-08-02-which-one-is-good-wp-or-drupal.md
+++ b/_posts/2009-08-02-which-one-is-good-wp-or-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: which one is good WP or drupal ?
-author: abrar.arshad
+author: abrar-arshad
 nid: 88
 comments: true
 redirect_from: /forum/topics/88/

--- a/_posts/2009-08-05-group-looking-for-a-simple-conference-website.md
+++ b/_posts/2009-08-05-group-looking-for-a-simple-conference-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Group Looking for a Simple Conference Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 97
 comments: true
 redirect_from: /forum/topics/97/

--- a/_posts/2009-08-05-irc-added-to-open-source-catholic.md
+++ b/_posts/2009-08-05-irc-added-to-open-source-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: IRC Added to Open Source Catholic
-author: Jeff Geerling
+author: geerlingguy
 nid: 92
 comments: true
 redirect_from: /blog/geerlingguy/irc-added-open-source-catholic/

--- a/_posts/2009-08-05-u-s-archdioceses-and-dioceses-on-facebook.md
+++ b/_posts/2009-08-05-u-s-archdioceses-and-dioceses-on-facebook.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: U.S. Archdioceses and Dioceses on Facebook
-author: Jeff Geerling
+author: geerlingguy
 nid: 93
 comments: true
 redirect_from: /blog/oscatholic/us-archdioceses-and-dioceses-faceb/

--- a/_posts/2009-08-09-status-updates.md
+++ b/_posts/2009-08-09-status-updates.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Status Updates
-author: Jeff Geerling
+author: geerlingguy
 nid: 104
 comments: true
 redirect_from: /blog/oscatholic/status-updates/

--- a/_posts/2009-08-10-open-source-catholic-moved-to-slicehost-updated.md
+++ b/_posts/2009-08-10-open-source-catholic-moved-to-slicehost-updated.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic Moved to Slicehost [Updated]
-author: Jeff Geerling
+author: geerlingguy
 nid: 105
 comments: true
 redirect_from: /content/open-source-catholic-moved-slicehos/

--- a/_posts/2009-08-12-data-quality.md
+++ b/_posts/2009-08-12-data-quality.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Data Quality
-author: Matt K
+author: matt-k
 nid: 110
 comments: true
 redirect_from: /forum/topics/110/

--- a/_posts/2009-08-17-question-about-running-a-freelance-business.md
+++ b/_posts/2009-08-17-question-about-running-a-freelance-business.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Question About Running A Freelance Business
-author: Cade_One
+author: cade-one
 nid: 112
 comments: true
 redirect_from: /forum/topics/112/

--- a/_posts/2009-08-20-building-catholic-parish-organization-websites.md
+++ b/_posts/2009-08-20-building-catholic-parish-organization-websites.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Building Catholic Parish/Organization Websites
-author: Jeff Geerling
+author: geerlingguy
 nid: 113
 comments: true
 redirect_from: /blog/geerlingguy/building-catholic-parishorganizat/

--- a/_posts/2009-08-20-open-source-equivalent-of-outlook-and-exchange-server.md
+++ b/_posts/2009-08-20-open-source-equivalent-of-outlook-and-exchange-server.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open source equivalent of Outlook and Exchange Server
-author: Matt K
+author: matt-k
 nid: 114
 comments: true
 redirect_from: /forum/topics/114/

--- a/_posts/2009-08-21-our-lady-of-mount-carmel-church-wants-to-go-digital-for-catechesis-any-thoughts.md
+++ b/_posts/2009-08-21-our-lady-of-mount-carmel-church-wants-to-go-digital-for-catechesis-any-thoughts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Our Lady of Mount Carmel Church wants to go Digital for Catechesis any thoughts?
-author: Valerie Shpak
+author: valerie-shpak
 nid: 116
 comments: true
 redirect_from: /forum/topics/116/

--- a/_posts/2009-08-21-random-bugfixes-for-internet-explorer-6-7.md
+++ b/_posts/2009-08-21-random-bugfixes-for-internet-explorer-6-7.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Random Bugfixes for Internet Explorer 6/7
-author: Jeff Geerling
+author: geerlingguy
 nid: 157
 comments: true
 redirect_from: /blog/oscatholic/random-bugfixes-internet/

--- a/_posts/2009-08-24-catholics-get-bashed-by-web-2-0-crowd.md
+++ b/_posts/2009-08-24-catholics-get-bashed-by-web-2-0-crowd.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholics Get Bashed by Web 2.0 Crowd
-author: 98faithCA
+author: 98faithca
 nid: 118
 comments: true
 redirect_from: /blog/98faithca/catholics-get-bashed-web-20-crowd/

--- a/_posts/2009-08-24-open-source-catholic-wiki.md
+++ b/_posts/2009-08-24-open-source-catholic-wiki.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic Wiki
-author: Jeff Geerling
+author: geerlingguy
 nid: 117
 comments: true
 redirect_from: /book/open-source-catholic-wiki/

--- a/_posts/2009-08-27-too-many-ways-to-contribute.md
+++ b/_posts/2009-08-27-too-many-ways-to-contribute.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Too many ways to contribute
-author: Joel Stein
+author: joel-stein
 nid: 120
 comments: true
 redirect_from: /forum/topics/120/

--- a/_posts/2009-08-28-commenter-with-similar-names.md
+++ b/_posts/2009-08-28-commenter-with-similar-names.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Commenter with similar names
-author: Matt K
+author: matt-k
 nid: 121
 comments: true
 redirect_from: /forum/topics/121/

--- a/_posts/2009-09-01-grassroots-films-new-vocation-video-for-new-york.md
+++ b/_posts/2009-09-01-grassroots-films-new-vocation-video-for-new-york.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Grassroots Films new vocation video for New York
-author: Matt K
+author: matt-k
 nid: 123
 comments: true
 redirect_from: /blog/matt-k/grassroots-films-new-vocation-video/

--- a/_posts/2009-09-01-markdownify-html-to-plain-text.md
+++ b/_posts/2009-09-01-markdownify-html-to-plain-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Markdownify: HTML to Plain Text'
-author: Joel Stein
+author: joel-stein
 nid: 124
 comments: true
 redirect_from: /forum/topics/124/

--- a/_posts/2009-09-03-open-source-software-catholic-teaching.md
+++ b/_posts/2009-09-03-open-source-software-catholic-teaching.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Software / Catholic Teaching
-author: Jeff Geerling
+author: geerlingguy
 nid: 125
 comments: true
 redirect_from: /blog/oscatholic/open-source-software-catholic-teac/

--- a/_posts/2009-09-06-drupal-theme-generators.md
+++ b/_posts/2009-09-06-drupal-theme-generators.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal Theme Generators
-author: JoaoMachado
+author: joaomachado
 nid: 127
 comments: true
 redirect_from: /forum/topics/127/

--- a/_posts/2009-09-09-moving-again-and-a-couple-updates-updated.md
+++ b/_posts/2009-09-09-moving-again-and-a-couple-updates-updated.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Moving Again... And a Couple Updates [UPDATED]
-author: Jeff Geerling
+author: geerlingguy
 nid: 128
 comments: true
 redirect_from: /content/moving-again-and-couple-updates-upd/

--- a/_posts/2009-09-11-need-your-input-guys.md
+++ b/_posts/2009-09-11-need-your-input-guys.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Need Your Input Guys
-author: Cade_One
+author: cade-one
 nid: 129
 comments: true
 redirect_from: /forum/topics/129/

--- a/_posts/2009-09-24-going-the-self-publishing-route.md
+++ b/_posts/2009-09-24-going-the-self-publishing-route.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Going the self-publishing route
-author: Jeffrey Pinyan - Praying the Mass
+author: jeffrey-pinyan-praying-the-mass
 nid: 132
 comments: true
 redirect_from: /blog/praying-mass/going-self-publishing-route/

--- a/_posts/2009-09-24-looking-for-catholic-webdevelopers-for-conference-website.md
+++ b/_posts/2009-09-24-looking-for-catholic-webdevelopers-for-conference-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Looking for Catholic Webdeveloper(s) for Conference Website
-author: Michael.Sullivan
+author: michael-sullivan
 nid: 133
 comments: true
 redirect_from: /forum/topics/133/

--- a/_posts/2009-09-29-top-5-drawbacks-of-joomla.md
+++ b/_posts/2009-09-29-top-5-drawbacks-of-joomla.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Top 5 drawbacks of Joomla
-author: Matt K
+author: matt-k
 nid: 134
 comments: true
 redirect_from: /forum/topics/134/

--- a/_posts/2009-10-07-are-macs-catholic.md
+++ b/_posts/2009-10-07-are-macs-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Are Macs Catholic?
-author: Jeff Geerling
+author: geerlingguy
 nid: 136
 comments: true
 redirect_from: /forum/topics/136/

--- a/_posts/2009-10-09-what-if.md
+++ b/_posts/2009-10-09-what-if.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: What if...?
-author: Jeff Geerling
+author: geerlingguy
 nid: 137
 comments: true
 redirect_from: /blog/oscatholic/what-if/

--- a/_posts/2009-10-18-fear-of-apples-reducing-complexity.md
+++ b/_posts/2009-10-18-fear-of-apples-reducing-complexity.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fear of Apples - Reducing Complexity
-author: Jeff Geerling
+author: geerlingguy
 nid: 141
 comments: true
 redirect_from: /blog/oscatholic/fear-apples-reducing-complexity/

--- a/_posts/2009-10-23-live-streaming-from-rome-quick-ustreaming-at-a-multicam-event.md
+++ b/_posts/2009-10-23-live-streaming-from-rome-quick-ustreaming-at-a-multicam-event.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Live Streaming from Rome - Quick Ustreaming at a Multicam Event
-author: Jeff Geerling
+author: geerlingguy
 nid: 142
 comments: true
 redirect_from: /blog/oscatholic/live-streaming-rome-quick-ustreami/

--- a/_posts/2009-10-27-what-makes-a-good-parish-website.md
+++ b/_posts/2009-10-27-what-makes-a-good-parish-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: What Makes a Good Parish Website?
-author: Jeff Geerling
+author: geerlingguy
 nid: 143
 comments: true
 redirect_from: /blog/oscatholic/what-makes-good-parish-website/

--- a/_posts/2009-10-29-bxvi-proclaim-the-gospel-on-the-digital-continent.md
+++ b/_posts/2009-10-29-bxvi-proclaim-the-gospel-on-the-digital-continent.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'BXVI: Proclaim the Gospel on the "Digital Continent"'
-author: Jeff Geerling
+author: geerlingguy
 nid: 144
 comments: true
 redirect_from: /blog/oscatholic/bxvi-proclaim-gospel-digital-conti/

--- a/_posts/2009-10-30-announcing-catholic-news-live.md
+++ b/_posts/2009-10-30-announcing-catholic-news-live.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Announcing Catholic News Live!
-author: Jeff Geerling
+author: geerlingguy
 nid: 147
 comments: true
 redirect_from: /blog/oscatholic/announcing-catholic-news/

--- a/_posts/2009-10-30-why-your-diocese-or-organization-needs-online-news-feeds.md
+++ b/_posts/2009-10-30-why-your-diocese-or-organization-needs-online-news-feeds.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Why Your Diocese or Organization Needs Online News Feeds
-author: Jeff Geerling
+author: geerlingguy
 nid: 145
 comments: true
 redirect_from: /blog/oscatholic/why-your-diocese-or-orga/

--- a/_posts/2009-11-05-catholics-called-to-communicate-with-charity.md
+++ b/_posts/2009-11-05-catholics-called-to-communicate-with-charity.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholics Called to Communicate with Charity
-author: Jeff Geerling
+author: geerlingguy
 nid: 152
 comments: true
 redirect_from: /blog/oscatholic/catholics-called-communi/

--- a/_posts/2009-11-10-news-companies-dont-want-their-content-stolen.md
+++ b/_posts/2009-11-10-news-companies-dont-want-their-content-stolen.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: News companies don't want their content "stolen"
-author: Matt K
+author: matt-k
 nid: 153
 comments: true
 redirect_from: /forum/topics/153/

--- a/_posts/2009-11-16-vatican-one-of-the-first-websites-still-hasnt-changed.md
+++ b/_posts/2009-11-16-vatican-one-of-the-first-websites-still-hasnt-changed.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican - One of the First Websites... Still Hasn't Changed?
-author: Jeff Geerling
+author: geerlingguy
 nid: 154
 comments: true
 redirect_from: /blog/oscatholic/vatican-one-first-websit/

--- a/_posts/2009-11-17-how-to-become-a-mac.md
+++ b/_posts/2009-11-17-how-to-become-a-mac.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to become a Mac
-author: Matt K
+author: matt-k
 nid: 155
 comments: true
 redirect_from: /forum/topics/155/

--- a/_posts/2009-11-17-want-link-juice-get-your-feed-on-catholic-news-live.md
+++ b/_posts/2009-11-17-want-link-juice-get-your-feed-on-catholic-news-live.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Want Link Juice? Get your Feed on Catholic News Live.
-author: Jeff Geerling
+author: geerlingguy
 nid: 151
 comments: true
 redirect_from: /blog/oscatholic/want-some-free-link-juic/

--- a/_posts/2009-11-19-google-chrome-os-screenshots.md
+++ b/_posts/2009-11-19-google-chrome-os-screenshots.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google Chrome OS screenshots
-author: Matt K
+author: matt-k
 nid: 156
 comments: true
 redirect_from: /forum/topics/156/

--- a/_posts/2009-11-21-a-few-site-updates.md
+++ b/_posts/2009-11-21-a-few-site-updates.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: A Few Site Updates
-author: Jeff Geerling
+author: geerlingguy
 nid: 163
 comments: true
 redirect_from: /blog/oscatholic/few-site-updates/

--- a/_posts/2009-11-24-linux-contractor-fired-for-using-firefox-linux.md
+++ b/_posts/2009-11-24-linux-contractor-fired-for-using-firefox-linux.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Linux Contractor Fired for Using Firefox/Linux...
-author: JoaoMachado
+author: joaomachado
 nid: 164
 comments: true
 redirect_from: /blog/joaomachado/linux-contractor-fired-/

--- a/_posts/2009-11-24-usccb-launches-new-advent-and-christmas-website-jettisons-strategy.md
+++ b/_posts/2009-11-24-usccb-launches-new-advent-and-christmas-website-jettisons-strategy.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: USCCB Launches New 'Advent and Christmas' Website - Jettisons Strategy?
-author: Jeff Geerling
+author: geerlingguy
 nid: 165
 comments: true
 redirect_from: /blog/oscatholic/usccb-launches-new-adven/

--- a/_posts/2009-11-25-dental-lab-website-re-design.md
+++ b/_posts/2009-11-25-dental-lab-website-re-design.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dental Lab Website Re-Design
-author: Cade_One
+author: cade-one
 nid: 166
 comments: true
 redirect_from: /forum/topics/166/

--- a/_posts/2009-11-26-windows-7-or-kde.md
+++ b/_posts/2009-11-26-windows-7-or-kde.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Windows 7 or KDE?
-author: JoaoMachado
+author: joaomachado
 nid: 167
 comments: true
 redirect_from: /blog/joaomachado/windows-7-or-kde/

--- a/_posts/2009-12-02-firefox-starts-taking-larger-marketshare.md
+++ b/_posts/2009-12-02-firefox-starts-taking-larger-marketshare.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: FireFox Starts Taking Larger Marketshare
-author: Jeff Geerling
+author: geerlingguy
 nid: 169
 comments: true
 redirect_from: /blog/oscatholic/firefox-starts-taking-la/

--- a/_posts/2009-12-02-he-sends-his-own-personal-emails.md
+++ b/_posts/2009-12-02-he-sends-his-own-personal-emails.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '"He sends his own personal emails!"'
-author: Jeff Geerling
+author: geerlingguy
 nid: 168
 comments: true
 redirect_from: /blog/oscatholic/he-sends-his-own-persona/

--- a/_posts/2009-12-05-ckeditor-installed-instead-of-fckeditor.md
+++ b/_posts/2009-12-05-ckeditor-installed-instead-of-fckeditor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CKEditor Installed instead of FCKEditor
-author: Jeff Geerling
+author: geerlingguy
 nid: 172
 comments: true
 redirect_from: /forum/topics/172/

--- a/_posts/2009-12-07-google-real-time-search-goes-live.md
+++ b/_posts/2009-12-07-google-real-time-search-goes-live.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google Real Time Search Goes Live
-author: Jeff Geerling
+author: geerlingguy
 nid: 175
 comments: true
 redirect_from: /forum/topics/175/

--- a/_posts/2009-12-07-need-a-simple-flash-ad-made-for-free.md
+++ b/_posts/2009-12-07-need-a-simple-flash-ad-made-for-free.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Need a simple Flash ad made for free
-author: JoaoMachado
+author: joaomachado
 nid: 174
 comments: true
 redirect_from: /forum/topics/174/

--- a/_posts/2009-12-09-how-do-i-remove-the-title-in-drupal.md
+++ b/_posts/2009-12-09-how-do-i-remove-the-title-in-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How Do I Remove The Title in Drupal?
-author: Cade_One
+author: cade-one
 nid: 177
 comments: true
 redirect_from: /forum/topics/177/

--- a/_posts/2009-12-10-websites-like-this-make-the-baby-jesus-cry.md
+++ b/_posts/2009-12-10-websites-like-this-make-the-baby-jesus-cry.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Websites like this make the baby Jesus cry...
-author: Jeff Geerling
+author: geerlingguy
 nid: 178
 comments: true
 redirect_from: /forum/topics/178/

--- a/_posts/2009-12-15-oh-ie-how-i-hate-thee.md
+++ b/_posts/2009-12-15-oh-ie-how-i-hate-thee.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Oh IE, how I Hate Thee
-author: Jeff Geerling
+author: geerlingguy
 nid: 187
 comments: true
 redirect_from: /blog/oscatholic/oh-ie-how-i-hate-thee/

--- a/_posts/2009-12-22-now-im-crying.md
+++ b/_posts/2009-12-22-now-im-crying.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Now I'm Crying...
-author: Jeff Geerling
+author: geerlingguy
 nid: 189
 comments: true
 redirect_from: /blog/oscatholic/now-im-crying/

--- a/_posts/2010-01-02-drupal-rss-feed-parsing-for-podcasts.md
+++ b/_posts/2010-01-02-drupal-rss-feed-parsing-for-podcasts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal RSS Feed parsing - For Podcasts
-author: JoaoMachado
+author: joaomachado
 nid: 191
 comments: true
 redirect_from: /forum/topics/191/

--- a/_posts/2010-01-05-windows-7-god-mode.md
+++ b/_posts/2010-01-05-windows-7-god-mode.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Windows 7 "God Mode"
-author: Matt K
+author: matt-k
 nid: 192
 comments: true
 redirect_from: /forum/topics/192/

--- a/_posts/2010-01-06-social-media-what-to-do-if-your-identity-brand-is-stolen.md
+++ b/_posts/2010-01-06-social-media-what-to-do-if-your-identity-brand-is-stolen.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Social Media: What to do if your Identity/Brand is Stolen'
-author: Jeff Geerling
+author: geerlingguy
 nid: 193
 comments: true
 redirect_from: /blog/oscatholic/social-media-what-do-if-/

--- a/_posts/2010-01-08-why-churches-should-not-market-by-matt-farina.md
+++ b/_posts/2010-01-08-why-churches-should-not-market-by-matt-farina.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '"Why Churches Should Not Market" (by Matt Farina)'
-author: Jeff Geerling
+author: geerlingguy
 nid: 195
 comments: true
 redirect_from: /forum/topics/195/

--- a/_posts/2010-01-19-wingdings-type-font-with-a-certain-character.md
+++ b/_posts/2010-01-19-wingdings-type-font-with-a-certain-character.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wingdings type font with a certain character
-author: Lurgid
+author: lurgid
 nid: 200
 comments: true
 redirect_from: /forum/topics/200/

--- a/_posts/2010-01-23-benedict-xvi-to-priests-use-new-technologies-to-evangelize-updated.md
+++ b/_posts/2010-01-23-benedict-xvi-to-priests-use-new-technologies-to-evangelize-updated.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Benedict XVI to Priests: Use New Technologies to Evangelize! [UPDATED]'
-author: Jeff Geerling
+author: geerlingguy
 nid: 202
 comments: true
 redirect_from: /blog/oscatholic/benedict-xvi-priests-use/

--- a/_posts/2010-01-25-hits-vs-visits-optimize-your-website.md
+++ b/_posts/2010-01-25-hits-vs-visits-optimize-your-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Hits vs. Visits - Optimize Your Website!
-author: Jeff Geerling
+author: geerlingguy
 nid: 203
 comments: true
 redirect_from: /blog/oscatholic/hits-vs-visits-optimize-/

--- a/_posts/2010-02-02-which-drupal-module-are-you-using-for-your-posting-interface.md
+++ b/_posts/2010-02-02-which-drupal-module-are-you-using-for-your-posting-interface.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Which Drupal module are you using for your posting interface?
-author: Cade_One
+author: cade-one
 nid: 206
 comments: true
 redirect_from: /forum/topics/206/

--- a/_posts/2010-02-15-mycatholic-com.md
+++ b/_posts/2010-02-15-mycatholic-com.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: mycatholic.com
-author: Matt K
+author: matt-k
 nid: 211
 comments: true
 redirect_from: /forum/topics/211/

--- a/_posts/2010-02-20-drupal-imagecache-display-alt-text-as-caption.md
+++ b/_posts/2010-02-20-drupal-imagecache-display-alt-text-as-caption.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal ImageCache - Display Alt Text as Caption
-author: Jeff Geerling
+author: geerlingguy
 nid: 212
 comments: true
 redirect_from: /blog/oscatholic/drupal-imagecache-displa/

--- a/_posts/2010-02-22-archdiocese-of-saint-louis-upgraded-website.md
+++ b/_posts/2010-02-22-archdiocese-of-saint-louis-upgraded-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Archdiocese of Saint Louis' Upgraded Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 198
 comments: true
 redirect_from: /blog/oscatholic/archdiocese-saint-louis-upgraded-website/

--- a/_posts/2010-02-22-prayercenter-using-drupal.md
+++ b/_posts/2010-02-22-prayercenter-using-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: PrayerCenter (using Drupal)
-author: Jeff Geerling
+author: geerlingguy
 nid: 204
 comments: true
 redirect_from: /blog/oscatholic/free-alternative-prayerc/

--- a/_posts/2010-03-03-drupal-gardens-beta-a-giant-leap-in-community-building.md
+++ b/_posts/2010-03-03-drupal-gardens-beta-a-giant-leap-in-community-building.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal Gardens Beta - A Giant Leap in Community Building...
-author: Jeff Geerling
+author: geerlingguy
 nid: 218
 comments: true
 redirect_from: /blog/oscatholic/drupal-gardens-beta-gian/

--- a/_posts/2010-03-19-osv-asks-how-effectively-does-your-parishs-website-connect.md
+++ b/_posts/2010-03-19-osv-asks-how-effectively-does-your-parishs-website-connect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'OSV Asks: How effectively does your parish''s website connect?'
-author: Jeff Geerling
+author: geerlingguy
 nid: 221
 comments: true
 redirect_from: /blog/oscatholic/osv-asks-how-effectively/

--- a/_posts/2010-03-25-new-drupal-book-drupal-6-performance-tips.md
+++ b/_posts/2010-03-25-new-drupal-book-drupal-6-performance-tips.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New Drupal Book - Drupal 6 Performance Tips
-author: trevor.james
+author: trevor-james
 nid: 225
 comments: true
 redirect_from: /blog/trevorjames/new-drupal-book-drupal-/

--- a/_posts/2010-03-25-please-stop-saying-web-2-0.md
+++ b/_posts/2010-03-25-please-stop-saying-web-2-0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Please Stop Saying "Web 2.0"
-author: Jeff Geerling
+author: geerlingguy
 nid: 224
 comments: true
 redirect_from: /blog/oscatholic/please-stop-saying-web-2/

--- a/_posts/2010-03-26-drupal-switching-content-types-the-easy-way.md
+++ b/_posts/2010-03-26-drupal-switching-content-types-the-easy-way.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Drupal: Switching Content Types the Easy Way'
-author: Jeff Geerling
+author: geerlingguy
 nid: 228
 comments: true
 redirect_from: /blog/oscatholic/drupal-switching-content/

--- a/_posts/2010-03-26-found-disc-diocesan-information-systems-conference.md
+++ b/_posts/2010-03-26-found-disc-diocesan-information-systems-conference.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Found: DISC (Diocesan Information Systems Conference)'
-author: Jeff Geerling
+author: geerlingguy
 nid: 226
 comments: true
 redirect_from: /blog/oscatholic/found-disc-diocesan-info/

--- a/_posts/2010-03-31-designers-these-days.md
+++ b/_posts/2010-03-31-designers-these-days.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Designers These Days...
-author: Jeff Geerling
+author: geerlingguy
 nid: 230
 comments: true
 redirect_from: /forum/topics/230/

--- a/_posts/2010-04-01-artisteer-templates-themes-made-easy.md
+++ b/_posts/2010-04-01-artisteer-templates-themes-made-easy.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Artisteer - Templates/Themes made easy
-author: Matt K
+author: matt-k
 nid: 232
 comments: true
 redirect_from: /forum/topics/232/

--- a/_posts/2010-04-01-one-page-quick-seo-optimization.md
+++ b/_posts/2010-04-01-one-page-quick-seo-optimization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: One-Page Quick SEO Optimization
-author: Jeff Geerling
+author: geerlingguy
 nid: 231
 comments: true
 redirect_from: /blog/oscatholic/one-page-quick-seo-optim/

--- a/_posts/2010-04-01-preparing-for-the-ipad.md
+++ b/_posts/2010-04-01-preparing-for-the-ipad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Preparing for the iPad...
-author: Jeff Geerling
+author: geerlingguy
 nid: 233
 comments: true
 redirect_from: /forum/topics/233/

--- a/_posts/2010-04-02-facebook-fan-pages.md
+++ b/_posts/2010-04-02-facebook-fan-pages.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Facebook Fan Pages
-author: Jeff Geerling
+author: geerlingguy
 nid: 238
 comments: true
 redirect_from: /wiki/facebook-fan-pages/

--- a/_posts/2010-04-02-facebook-groups.md
+++ b/_posts/2010-04-02-facebook-groups.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Facebook Groups
-author: Jeff Geerling
+author: geerlingguy
 nid: 237
 comments: true
 redirect_from: /wiki/facebook-groups/

--- a/_posts/2010-04-02-facebook.md
+++ b/_posts/2010-04-02-facebook.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Facebook
-author: Jeff Geerling
+author: geerlingguy
 nid: 235
 comments: true
 redirect_from: /wiki/facebook/

--- a/_posts/2010-04-02-social-networking-and-online-community.md
+++ b/_posts/2010-04-02-social-networking-and-online-community.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Social Networking and Online Community
-author: Jeff Geerling
+author: geerlingguy
 nid: 234
 comments: true
 redirect_from: /wiki/social-networking-and-onl/

--- a/_posts/2010-04-02-streaming-media.md
+++ b/_posts/2010-04-02-streaming-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Streaming Media
-author: Jeff Geerling
+author: geerlingguy
 nid: 240
 comments: true
 redirect_from: /wiki/streaming-media/

--- a/_posts/2010-04-02-twitter.md
+++ b/_posts/2010-04-02-twitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Twitter
-author: Jeff Geerling
+author: geerlingguy
 nid: 239
 comments: true
 redirect_from: /wiki/twitter/

--- a/_posts/2010-04-02-website-design-development-and-maintenance.md
+++ b/_posts/2010-04-02-website-design-development-and-maintenance.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Design, Development, and Maintenance
-author: Jeff Geerling
+author: geerlingguy
 nid: 241
 comments: true
 redirect_from: /wiki/website-design-developmen/

--- a/_posts/2010-04-02-wiki-stub-pages.md
+++ b/_posts/2010-04-02-wiki-stub-pages.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wiki Stub Pages
-author: Jeff Geerling
+author: geerlingguy
 nid: 236
 comments: true
 redirect_from: /forum/topics/236/

--- a/_posts/2010-04-03-major-updates-to-open-source-catholic.md
+++ b/_posts/2010-04-03-major-updates-to-open-source-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Major Updates to Open Source Catholic!
-author: Jeff Geerling
+author: geerlingguy
 nid: 242
 comments: true
 redirect_from: /blog/oscatholic/major-updates-open-sourc/

--- a/_posts/2010-04-12-quote-demonstrating-bad-software-design.md
+++ b/_posts/2010-04-12-quote-demonstrating-bad-software-design.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quote demonstrating bad software design
-author: jr.duboc
+author: jr-duboc
 nid: 244
 comments: true
 redirect_from: /blog/jrduboc/quote-demonstrating-bad-s/

--- a/_posts/2010-04-13-basic-data-collection-online-forms.md
+++ b/_posts/2010-04-13-basic-data-collection-online-forms.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Basic Data Collection - Online Forms
-author: Jeff Geerling
+author: geerlingguy
 nid: 246
 comments: true
 redirect_from: /wiki/basic-data-collection-onl/

--- a/_posts/2010-04-13-event-registrations-and-management.md
+++ b/_posts/2010-04-13-event-registrations-and-management.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Event Registrations and Management
-author: Jeff Geerling
+author: geerlingguy
 nid: 247
 comments: true
 redirect_from: /wiki/117/event-registrations-and-m/

--- a/_posts/2010-04-13-forms-registrations-and-online-event-management.md
+++ b/_posts/2010-04-13-forms-registrations-and-online-event-management.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Forms, Registrations, and Online Event Management
-author: Jeff Geerling
+author: geerlingguy
 nid: 245
 comments: true
 redirect_from: /wiki/forms-registrations-and-o/

--- a/_posts/2010-04-19-first-iphone-app-from-the-vatican.md
+++ b/_posts/2010-04-19-first-iphone-app-from-the-vatican.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'First iPhone App from the Vatican:'
-author: Jeff Geerling
+author: geerlingguy
 nid: 249
 comments: true
 redirect_from: /blog/oscatholic/first-iphone-app-vatican/

--- a/_posts/2010-04-20-email-marketing-tools-and-strategies.md
+++ b/_posts/2010-04-20-email-marketing-tools-and-strategies.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Email Marketing Tools and Strategies
-author: Jeff Geerling
+author: geerlingguy
 nid: 252
 comments: true
 redirect_from: /wiki/117/email-marketing-tools-and/

--- a/_posts/2010-04-20-live-streaming-from-an-event-using-ustream.md
+++ b/_posts/2010-04-20-live-streaming-from-an-event-using-ustream.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Live Streaming from an Event using Ustream
-author: Jeff Geerling
+author: geerlingguy
 nid: 254
 comments: true
 redirect_from: /wiki/117/live-streaming-event/

--- a/_posts/2010-04-20-online-marketing-tools-and-strategies.md
+++ b/_posts/2010-04-20-online-marketing-tools-and-strategies.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Online Marketing Tools and Strategies
-author: Jeff Geerling
+author: geerlingguy
 nid: 251
 comments: true
 redirect_from: /wiki/117/online-marketing-tools-an/

--- a/_posts/2010-04-20-website-performance.md
+++ b/_posts/2010-04-20-website-performance.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Performance
-author: Jeff Geerling
+author: geerlingguy
 nid: 250
 comments: true
 redirect_from: /wiki/117/website-performance/

--- a/_posts/2010-04-22-certified-to-rock-neat-drupal-user-involvement-measurement-tool.md
+++ b/_posts/2010-04-22-certified-to-rock-neat-drupal-user-involvement-measurement-tool.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Certified to Rock - Neat Drupal User Involvement Measurement Tool
-author: Jeff Geerling
+author: geerlingguy
 nid: 255
 comments: true
 redirect_from: /blog/oscatholic/certified-rock-neat/

--- a/_posts/2010-04-28-plan-for-emergenciesbefore-they-happen.md
+++ b/_posts/2010-04-28-plan-for-emergenciesbefore-they-happen.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Plan for Emergencies—Before they Happen
-author: Jeff Geerling
+author: geerlingguy
 nid: 257
 comments: true
 redirect_from: /blog/oscatholic/plan-emergencies—-they-h/

--- a/_posts/2010-04-28-speeding-up-a-site-quicker-404-errors-for-files-in-drupal.md
+++ b/_posts/2010-04-28-speeding-up-a-site-quicker-404-errors-for-files-in-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Speeding up a Site: Quicker 404 Errors for files in Drupal'
-author: Jeff Geerling
+author: geerlingguy
 nid: 256
 comments: true
 redirect_from: /blog/oscatholic/speeding-site-quicker/

--- a/_posts/2010-04-29-franciscan-monks-involved-in-drupal-core-development.md
+++ b/_posts/2010-04-29-franciscan-monks-involved-in-drupal-core-development.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Franciscan Monks Involved in Drupal Core Development!
-author: Jeff Geerling
+author: geerlingguy
 nid: 259
 comments: true
 redirect_from: /blog/oscatholic/franciscan-monks/

--- a/_posts/2010-04-29-vatican-secret-archive-is-digitizing-to-open-fits-format.md
+++ b/_posts/2010-04-29-vatican-secret-archive-is-digitizing-to-open-fits-format.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican Secret Archive is Digitizing to Open FITS Format
-author: Jeff Geerling
+author: geerlingguy
 nid: 258
 comments: true
 redirect_from: /blog/oscatholic/vatican-secret-archive/

--- a/_posts/2010-04-30-resetting-files-table-after-drupal-4-7-x-6-x-upgrade.md
+++ b/_posts/2010-04-30-resetting-files-table-after-drupal-4-7-x-6-x-upgrade.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Resetting Files Table after Drupal 4.7.x -> 6.x Upgrade
-author: Jeff Geerling
+author: geerlingguy
 nid: 260
 comments: true
 redirect_from: /blog/oscatholic/resetting-files-table/

--- a/_posts/2010-05-01-catholictuner-com-up-for-sale-price-0.md
+++ b/_posts/2010-05-01-catholictuner-com-up-for-sale-price-0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CatholicTuner.com up for sale, Price $0
-author: JoaoMachado
+author: joaomachado
 nid: 261
 comments: true
 redirect_from: /forum/topics/261/

--- a/_posts/2010-05-04-creating-a-more-friendly-404-page.md
+++ b/_posts/2010-05-04-creating-a-more-friendly-404-page.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Creating a More Friendly 404 Page
-author: Jeff Geerling
+author: geerlingguy
 nid: 263
 comments: true
 redirect_from: /blog/oscatholic/creating-more-friendly/

--- a/_posts/2010-05-04-our-designs-have-to-reflect-christ.md
+++ b/_posts/2010-05-04-our-designs-have-to-reflect-christ.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Our Designs Have to Reflect Christ
-author: Jeff Geerling
+author: geerlingguy
 nid: 262
 comments: true
 redirect_from: /blog/oscatholic/our-designs-have-reflect/

--- a/_posts/2010-05-12-vatican-announces-upgrade-of-network-infrastructure.md
+++ b/_posts/2010-05-12-vatican-announces-upgrade-of-network-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican Announces Upgrade of Network Infrastructure
-author: Jeff Geerling
+author: geerlingguy
 nid: 264
 comments: true
 redirect_from: /blog/oscatholic/vatican-announces/

--- a/_posts/2010-05-14-post-photos-to-your-drupal-site-from-the-ipad.md
+++ b/_posts/2010-05-14-post-photos-to-your-drupal-site-from-the-ipad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Post Photos to Your Drupal Site from the iPad
-author: Jeff Geerling
+author: geerlingguy
 nid: 265
 comments: true
 redirect_from: /blog/oscatholic/post-photos-your-drupal/

--- a/_posts/2010-05-20-dont-neglect-your-print-css-file.md
+++ b/_posts/2010-05-20-dont-neglect-your-print-css-file.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Don't Neglect Your print.css file!
-author: Jeff Geerling
+author: geerlingguy
 nid: 267
 comments: true
 redirect_from: /blog/oscatholic/dont-neglect-your/

--- a/_posts/2010-05-20-googles-new-open-font-library.md
+++ b/_posts/2010-05-20-googles-new-open-font-library.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google's New Open Font Library
-author: Jeff Geerling
+author: geerlingguy
 nid: 266
 comments: true
 redirect_from: /blog/oscatholic/googles-new-open-font/

--- a/_posts/2010-05-21-set-a-views-context-inside-an-organic-group.md
+++ b/_posts/2010-05-21-set-a-views-context-inside-an-organic-group.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Set a View's Context Inside an Organic Group
-author: Jeff Geerling
+author: geerlingguy
 nid: 268
 comments: true
 redirect_from: /blog/oscatholic/set-views-context-inside/

--- a/_posts/2010-05-24-stupid-flash-making-menus-appear-over-flash-video-content.md
+++ b/_posts/2010-05-24-stupid-flash-making-menus-appear-over-flash-video-content.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stupid Flash – Making Menus Appear Over Flash Video/Content
-author: Jeff Geerling
+author: geerlingguy
 nid: 269
 comments: true
 redirect_from: /blog/oscatholic/stupid-flash-–-making-m/

--- a/_posts/2010-06-03-drupal-restoring-core-comment-title-permalinks-in-a-zen-subtheme.md
+++ b/_posts/2010-06-03-drupal-restoring-core-comment-title-permalinks-in-a-zen-subtheme.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Drupal: Restoring core comment title permalinks in a Zen Subtheme'
-author: Jeff Geerling
+author: geerlingguy
 nid: 273
 comments: true
 redirect_from: /blog/oscatholic/drupal-restoring-core/

--- a/_posts/2010-06-03-from-the-catholic-media-conference-in-la.md
+++ b/_posts/2010-06-03-from-the-catholic-media-conference-in-la.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: From the Catholic Media Conference (in LA)
-author: Jeff Geerling
+author: geerlingguy
 nid: 272
 comments: true
 redirect_from: /blog/oscatholic/catholic-media/

--- a/_posts/2010-06-04-the-parish-website-an-essential-tool-for-ministry.md
+++ b/_posts/2010-06-04-the-parish-website-an-essential-tool-for-ministry.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'The Parish Website: An Essential Tool for Ministry'
-author: Carson Weber
+author: carson-weber
 nid: 274
 comments: true
 redirect_from: /blog/carson-weber/parish-website/

--- a/_posts/2010-06-06-connecting-to-the-facebook-api.md
+++ b/_posts/2010-06-06-connecting-to-the-facebook-api.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Connecting to the Facebook API
-author: Jeff Geerling
+author: geerlingguy
 nid: 276
 comments: true
 redirect_from: /wiki/117/connecting-facebook-api/

--- a/_posts/2010-06-07-the-real-time-web-staying-relevant.md
+++ b/_posts/2010-06-07-the-real-time-web-staying-relevant.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Real-Time Web – Staying Relevant
-author: Jeff Geerling
+author: geerlingguy
 nid: 277
 comments: true
 redirect_from: /blog/oscatholic/real-time-web-–-staying-r/

--- a/_posts/2010-06-08-news-websites-make-your-news-readable.md
+++ b/_posts/2010-06-08-news-websites-make-your-news-readable.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'News Websites: Make Your News Readable!'
-author: Jeff Geerling
+author: geerlingguy
 nid: 278
 comments: true
 redirect_from: /blog/oscatholic/news-websites-make-your/

--- a/_posts/2010-06-15-catholic-youth-apostolate-in-st-louis-looking-for-ft-web-developer.md
+++ b/_posts/2010-06-15-catholic-youth-apostolate-in-st-louis-looking-for-ft-web-developer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Youth Apostolate in St. Louis looking for FT Web Developer
-author: Jeff Geerling
+author: geerlingguy
 nid: 281
 comments: true
 redirect_from: /forum/topics/281/

--- a/_posts/2010-06-15-redesign-project-students-for-life-michigan.md
+++ b/_posts/2010-06-15-redesign-project-students-for-life-michigan.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Redesign Project: Students for Life Michigan'
-author: Jeff Geerling
+author: geerlingguy
 nid: 282
 comments: true
 redirect_from: /forum/topics/282/

--- a/_posts/2010-06-17-posting-documents-for-web-in-word-format-and-defending-the-decision.md
+++ b/_posts/2010-06-17-posting-documents-for-web-in-word-format-and-defending-the-decision.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Posting documents for web in Word format ...... and defending the decision
-author: Matt K
+author: matt-k
 nid: 284
 comments: true
 redirect_from: /forum/topics/284/

--- a/_posts/2010-06-17-use-text-instead-of-text-in-a-picture-flier-for-your-website.md
+++ b/_posts/2010-06-17-use-text-instead-of-text-in-a-picture-flier-for-your-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Use Text Instead of Text-in-a-Picture/Flier for your Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 283
 comments: true
 redirect_from: /blog/oscatholic/use-text-instead-text/

--- a/_posts/2010-06-18-celebrating-the-holy-mass-from-an-ipad.md
+++ b/_posts/2010-06-18-celebrating-the-holy-mass-from-an-ipad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Celebrating the Holy Mass from an iPad
-author: Jeff Geerling
+author: geerlingguy
 nid: 286
 comments: true
 redirect_from: /blog/geerlingguy/celebrating-holy-mass/

--- a/_posts/2010-06-25-ma-parish-using-social-media-website-effectively.md
+++ b/_posts/2010-06-25-ma-parish-using-social-media-website-effectively.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: MA Parish Using Social Media/Website Effectively
-author: Jeff Geerling
+author: geerlingguy
 nid: 288
 comments: true
 redirect_from: /blog/oscatholic/ma-parish-using-social/

--- a/_posts/2010-06-29-setting-up-an-apache-solr-search-server-for-many-sites-hosts.md
+++ b/_posts/2010-06-29-setting-up-an-apache-solr-search-server-for-many-sites-hosts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Setting up an Apache Solr Search Server (for many sites/hosts)
-author: Jeff Geerling
+author: geerlingguy
 nid: 289
 comments: true
 redirect_from: /blog/oscatholic/setting-apache-solr/

--- a/_posts/2010-07-02-archdioceses-getting-on-board-with-online-evangelization.md
+++ b/_posts/2010-07-02-archdioceses-getting-on-board-with-online-evangelization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "(Arch)Dioceses Getting On Board with Online Evangelization"
-author: Jeff Geerling
+author: geerlingguy
 nid: 290
 comments: true
 redirect_from: /blog/oscatholic/archdioceses-getting/

--- a/_posts/2010-07-08-social-media-policies.md
+++ b/_posts/2010-07-08-social-media-policies.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Social Media Policies
-author: Jeff Geerling
+author: geerlingguy
 nid: 293
 comments: true
 redirect_from: /wiki/117/social-media-policies/

--- a/_posts/2010-07-08-usccb-social-media-guidelines.md
+++ b/_posts/2010-07-08-usccb-social-media-guidelines.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: USCCB Social Media Guidelines
-author: Jeff Geerling
+author: geerlingguy
 nid: 292
 comments: true
 redirect_from: /blog/oscatholic/usccb-social-media/

--- a/_posts/2010-07-12-catholics-are-my-last-resort.md
+++ b/_posts/2010-07-12-catholics-are-my-last-resort.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholics are my last resort...
-author: JoaoMachado
+author: joaomachado
 nid: 295
 comments: true
 redirect_from: /forum/topics/295/

--- a/_posts/2010-07-16-live-blogging-to-drive-traffic-interest-to-organizational-events.md
+++ b/_posts/2010-07-16-live-blogging-to-drive-traffic-interest-to-organizational-events.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Live-Blogging to Drive Traffic, Interest to Organizational Events
-author: Jeff Geerling
+author: geerlingguy
 nid: 297
 comments: true
 redirect_from: /blog/geerlingguy/live-blogging-drive/

--- a/_posts/2010-07-16-using-drupal-with-amazon-s3-to-backup-your-site.md
+++ b/_posts/2010-07-16-using-drupal-with-amazon-s3-to-backup-your-site.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Using Drupal with Amazon S3 to backup your site
-author: JoaoMachado
+author: joaomachado
 nid: 296
 comments: true
 redirect_from: /forum/topics/296/

--- a/_posts/2010-07-19-vatican-website-may-have-been-google-bombing-victim.md
+++ b/_posts/2010-07-19-vatican-website-may-have-been-google-bombing-victim.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican website may have been 'Google bombing' victim
-author: Matt K
+author: matt-k
 nid: 298
 comments: true
 redirect_from: /blog/matt-k/vatican-website-may-have/

--- a/_posts/2010-07-22-drupal-gardens-enters-open-public-beta.md
+++ b/_posts/2010-07-22-drupal-gardens-enters-open-public-beta.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal Gardens enters Open Public Beta
-author: Jeff Geerling
+author: geerlingguy
 nid: 299
 comments: true
 redirect_from: /blog/oscatholic/drupal-gardens-enters/

--- a/_posts/2010-07-23-catholic-programmers-t-shirt-and-mousepad.md
+++ b/_posts/2010-07-23-catholic-programmers-t-shirt-and-mousepad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Programmer's T-Shirt and Mousepad
-author: Jeff Geerling
+author: geerlingguy
 nid: 300
 comments: true
 redirect_from: /blog/geerlingguy/catholic-programmers-t/

--- a/_posts/2010-07-27-study-shows-2-3-of-churches-not-using-any-social-media.md
+++ b/_posts/2010-07-27-study-shows-2-3-of-churches-not-using-any-social-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Study shows 2/3 of Churches not using any Social Media
-author: Jeff Geerling
+author: geerlingguy
 nid: 301
 comments: true
 redirect_from: /blog/oscatholic/study-shows-23-churches/

--- a/_posts/2010-08-05-easy-embedding-of-html5-video-on-a-drupal-site.md
+++ b/_posts/2010-08-05-easy-embedding-of-html5-video-on-a-drupal-site.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Easy Embedding of HTML5 Video on a Drupal Site
-author: Jeff Geerling
+author: geerlingguy
 nid: 302
 comments: true
 redirect_from: /blog/oscatholic/easy-embedding-html5-vid/

--- a/_posts/2010-08-05-website-design-tools-and-resources.md
+++ b/_posts/2010-08-05-website-design-tools-and-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Design Tools and Resources
-author: Jeff Geerling
+author: geerlingguy
 nid: 304
 comments: true
 redirect_from: /wiki/117/website-design-tools-and/

--- a/_posts/2010-08-05-website-development-companies-and-resources.md
+++ b/_posts/2010-08-05-website-development-companies-and-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Development Companies and Resources
-author: Jeff Geerling
+author: geerlingguy
 nid: 303
 comments: true
 redirect_from: /wiki/117/website-development-compa/

--- a/_posts/2010-08-09-osc-users-rss-feeds-soon-to-be-aggregated.md
+++ b/_posts/2010-08-09-osc-users-rss-feeds-soon-to-be-aggregated.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OSC Users' RSS Feeds... soon to be aggregated
-author: Jeff Geerling
+author: geerlingguy
 nid: 305
 comments: true
 redirect_from: /blog/oscatholic/osc-users-rss-feeds-soon/

--- a/_posts/2010-08-12-vatican-va-getting-an-upgrade.md
+++ b/_posts/2010-08-12-vatican-va-getting-an-upgrade.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican.va Getting an Upgrade!
-author: Jeff Geerling
+author: geerlingguy
 nid: 306
 comments: true
 redirect_from: /blog/oscatholic/vaticanva-getting-upgrad/

--- a/_posts/2010-08-16-embed-the-breviary-and-other-prayers-on-your-site.md
+++ b/_posts/2010-08-16-embed-the-breviary-and-other-prayers-on-your-site.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Embed the Breviary (and other Prayers) on your Site
-author: Jeff Geerling
+author: geerlingguy
 nid: 307
 comments: true
 redirect_from: /forum/topics/307/

--- a/_posts/2010-08-18-is-there-a-module-for-that.md
+++ b/_posts/2010-08-18-is-there-a-module-for-that.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Is there a module for that?
-author: Jeff Geerling
+author: geerlingguy
 nid: 308
 comments: true
 redirect_from: /blog/oscatholic/there-module/

--- a/_posts/2010-08-26-5-steps-to-get-a-million-monthly-visitors-to-your-website.md
+++ b/_posts/2010-08-26-5-steps-to-get-a-million-monthly-visitors-to-your-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 5 Steps to Get a Million Monthly Visitors to your Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 309
 comments: true
 redirect_from: /blog/oscatholic/5-steps-get-million-mont/

--- a/_posts/2010-08-27-open-source-catholic-challenge-rosary-in-html5.md
+++ b/_posts/2010-08-27-open-source-catholic-challenge-rosary-in-html5.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Open Source Catholic Challenge: Rosary in HTML5'
-author: Jeff Geerling
+author: geerlingguy
 nid: 311
 comments: true
 redirect_from: /blog/oscatholic/open-source-catholic-cha/

--- a/_posts/2010-08-27-two-trackbacks-first-things-and-opensource-com.md
+++ b/_posts/2010-08-27-two-trackbacks-first-things-and-opensource-com.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Two Trackbacks - First Things & OpenSource.com
-author: Jeff Geerling
+author: geerlingguy
 nid: 310
 comments: true
 redirect_from: /blog/oscatholic/two-trackbacks-first-thi/

--- a/_posts/2010-08-29-parish-school-websites.md
+++ b/_posts/2010-08-29-parish-school-websites.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Parish School Websites
-author: Jeff Geerling
+author: geerlingguy
 nid: 313
 comments: true
 redirect_from: /wiki/117/parish-school-websites/

--- a/_posts/2010-08-30-found-on-ncr-how-are-parishes-using-new-media.md
+++ b/_posts/2010-08-30-found-on-ncr-how-are-parishes-using-new-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Found on NCR: How are parishes using new media?'
-author: Jeff Geerling
+author: geerlingguy
 nid: 317
 comments: true
 redirect_from: /blog/oscatholic/found-ncr-how-are-parish/

--- a/_posts/2010-08-30-working-on-a-new-intranet-sharepoint-vs-drupal.md
+++ b/_posts/2010-08-30-working-on-a-new-intranet-sharepoint-vs-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Working on a new Intranet - Sharepoint vs. Drupal
-author: Jeff Geerling
+author: geerlingguy
 nid: 316
 comments: true
 redirect_from: /forum/topics/316/

--- a/_posts/2010-09-01-new-twitter-hashtag-for-catholic-media-social-media.md
+++ b/_posts/2010-09-01-new-twitter-hashtag-for-catholic-media-social-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New Twitter Hashtag for Catholic Media, Social Media
-author: Jeff Geerling
+author: geerlingguy
 nid: 320
 comments: true
 redirect_from: /blog/oscatholic/new-twitter-hashtag-cath/

--- a/_posts/2010-09-02-any-way-to-transfer-calendar-data-into-out-of-exchange.md
+++ b/_posts/2010-09-02-any-way-to-transfer-calendar-data-into-out-of-exchange.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Any Way to Transfer Calendar Data into/out of Exchange?
-author: Jeff Geerling
+author: geerlingguy
 nid: 321
 comments: true
 redirect_from: /forum/topics/321/

--- a/_posts/2010-09-16-debian-with-a-refreshing-minty-flavor.md
+++ b/_posts/2010-09-16-debian-with-a-refreshing-minty-flavor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Debian With a Refreshing Minty Flavor
-author: Steely
+author: steely
 nid: 324
 comments: true
 redirect_from: /blog/steely/debian-refreshing-minty-f/

--- a/_posts/2010-09-16-looking-for-custom-web-developer-with-extensive-wordpress-knowledge.md
+++ b/_posts/2010-09-16-looking-for-custom-web-developer-with-extensive-wordpress-knowledge.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Looking for Custom Web Developer with Extensive Wordpress Knowledge
-author: Dr Peter Howard
+author: dr-peter-howard
 nid: 325
 comments: true
 redirect_from: /forum/topics/325/

--- a/_posts/2010-09-17-looking-for-custom-web-developer-with-extensive-wordpress-knowledge.md
+++ b/_posts/2010-09-17-looking-for-custom-web-developer-with-extensive-wordpress-knowledge.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Looking for Custom Web Developer with Extensive Wordpress Knowledge
-author: Dr Peter Howard
+author: dr-peter-howard
 nid: 326
 comments: true
 redirect_from: /blog/dr-peter-howard/looking-custom-web-/

--- a/_posts/2010-09-21-website-hosting-management-dns-information.md
+++ b/_posts/2010-09-21-website-hosting-management-dns-information.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Hosting Management, DNS Information
-author: Jeff Geerling
+author: geerlingguy
 nid: 328
 comments: true
 redirect_from: /wiki/117/website-hosting-managemen/

--- a/_posts/2010-09-24-social-media-strategy-for-your-parish.md
+++ b/_posts/2010-09-24-social-media-strategy-for-your-parish.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Social Media Strategy for your Parish
-author: Jeff Geerling
+author: geerlingguy
 nid: 332
 comments: true
 redirect_from: /blog/oscatholic/social-media-strategy-yo/

--- a/_posts/2010-09-24-useful-comment-notification-emails-for-drupal-site-admins.md
+++ b/_posts/2010-09-24-useful-comment-notification-emails-for-drupal-site-admins.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Useful Comment Notification Emails for Drupal Site Admins
-author: Jeff Geerling
+author: geerlingguy
 nid: 331
 comments: true
 redirect_from: /blog/oscatholic/useful-comment-notificat/

--- a/_posts/2010-10-01-java-script-question.md
+++ b/_posts/2010-10-01-java-script-question.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Java Script question
-author: JoaoMachado
+author: joaomachado
 nid: 333
 comments: true
 redirect_from: /forum/topics/333/

--- a/_posts/2010-10-11-free-ebook-getting-good-with-git.md
+++ b/_posts/2010-10-11-free-ebook-getting-good-with-git.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Free eBook: Getting Good with Git'
-author: Jeff Geerling
+author: geerlingguy
 nid: 334
 comments: true
 redirect_from: /blog/jeff-geerling/free-ebook-getting-go/

--- a/_posts/2010-10-12-pope-unveils-new-agency-to-promote-new-evangelization.md
+++ b/_posts/2010-10-12-pope-unveils-new-agency-to-promote-new-evangelization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pope unveils new agency to promote 'new evangelization'
-author: Jeff Geerling
+author: geerlingguy
 nid: 335
 comments: true
 redirect_from: /blog/oscatholic/pope-unveils-new-agency-/

--- a/_posts/2010-10-14-mass-attendance-rose-7-4-as-result-of-marketing-website.md
+++ b/_posts/2010-10-14-mass-attendance-rose-7-4-as-result-of-marketing-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mass Attendance Rose 7.4% as result of Marketing/Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 337
 comments: true
 redirect_from: /blog/oscatholic/mass-attendance-rose-74-/

--- a/_posts/2010-10-18-tar-gzip-directory-without-preserving-directory-heirarchy-structure.md
+++ b/_posts/2010-10-18-tar-gzip-directory-without-preserving-directory-heirarchy-structure.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tar/Gzip Directory without Preserving Directory Heirarchy/Structure
-author: Jeff Geerling
+author: geerlingguy
 nid: 338
 comments: true
 redirect_from: /blog/oscatholic/targzip-directory-withou/

--- a/_posts/2010-10-18-the-value-of-open-source-contributing-back.md
+++ b/_posts/2010-10-18-the-value-of-open-source-contributing-back.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Value of Open Source / Contributing Back
-author: Jeff Geerling
+author: geerlingguy
 nid: 339
 comments: true
 redirect_from: /blog/oscatholic/value-open-source-contri/

--- a/_posts/2010-10-20-twitter-module-on-osc-updated-to-use-oauth.md
+++ b/_posts/2010-10-20-twitter-module-on-osc-updated-to-use-oauth.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Twitter Module on OSC Updated to use OAuth
-author: Jeff Geerling
+author: geerlingguy
 nid: 341
 comments: true
 redirect_from: /blog/oscatholic/twitter-module-osc-updat/

--- a/_posts/2010-10-22-facebook-teams-up-with-gay-activist-orgs-to-stop-hateful-comments.md
+++ b/_posts/2010-10-22-facebook-teams-up-with-gay-activist-orgs-to-stop-hateful-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Facebook Teams Up with Gay Activist Orgs to Stop ‘Hateful’ Comments
-author: Matt K
+author: matt-k
 nid: 342
 comments: true
 redirect_from: /forum/topics/342/

--- a/_posts/2010-10-29-create-a-podcast-quick-n-easy-using-drupal-with-views-filefield.md
+++ b/_posts/2010-10-29-create-a-podcast-quick-n-easy-using-drupal-with-views-filefield.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Create a Podcast, Quick n' Easy, using Drupal with Views + FileField
-author: Jeff Geerling
+author: geerlingguy
 nid: 345
 comments: true
 redirect_from: /blog/oscatholic/create-podcast-quick-n-e/

--- a/_posts/2010-10-29-how-to-build-a-drupal-module-for-beginners.md
+++ b/_posts/2010-10-29-how-to-build-a-drupal-module-for-beginners.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to Build a Drupal Module - for Beginners
-author: Jeff Geerling
+author: geerlingguy
 nid: 344
 comments: true
 redirect_from: /blog/oscatholic/how-build-drupal-module-/

--- a/_posts/2010-11-02-sharing-parish-directory-information-online.md
+++ b/_posts/2010-11-02-sharing-parish-directory-information-online.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sharing Parish Directory Information Online
-author: Jeff Geerling
+author: geerlingguy
 nid: 346
 comments: true
 redirect_from: /forum/topics/346/

--- a/_posts/2010-11-04-the-importance-of-accessibility-on-the-web.md
+++ b/_posts/2010-11-04-the-importance-of-accessibility-on-the-web.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Importance of Accessibility on the Web
-author: Jeff Geerling
+author: geerlingguy
 nid: 347
 comments: true
 redirect_from: /blog/jeff-geerling/importance-accessibil/

--- a/_posts/2010-11-04-website-accessibility-for-persons-with-disabilities.md
+++ b/_posts/2010-11-04-website-accessibility-for-persons-with-disabilities.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Accessibility for Persons with Disabilities
-author: Jeff Geerling
+author: geerlingguy
 nid: 348
 comments: true
 redirect_from: /wiki/117/website-accessibility-per/

--- a/_posts/2010-11-08-flocknote-catholic-parish-organization-registration.md
+++ b/_posts/2010-11-08-flocknote-catholic-parish-organization-registration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: FlockNote - Catholic parish/organization Registration
-author: Jeff Geerling
+author: geerlingguy
 nid: 349
 comments: true
 redirect_from: /wiki/117/flocknote-catholic-parish/

--- a/_posts/2010-11-09-has-anyone-used-claroline.md
+++ b/_posts/2010-11-09-has-anyone-used-claroline.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Has anyone used Claroline?
-author: JMMR
+author: jmmr
 nid: 350
 comments: true
 redirect_from: /forum/topics/350/

--- a/_posts/2010-11-11-2011-social-media-tipping-point-for-the-catholic-church.md
+++ b/_posts/2010-11-11-2011-social-media-tipping-point-for-the-catholic-church.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '2011: Social Media Tipping Point for the Catholic Church'
-author: Jeff Geerling
+author: geerlingguy
 nid: 351
 comments: true
 redirect_from: /blog/oscatholic/2011-social-media-tippin/

--- a/_posts/2010-11-11-embedding-a-related-content-block-in-your-drupal-nodes.md
+++ b/_posts/2010-11-11-embedding-a-related-content-block-in-your-drupal-nodes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Embedding a 'Related Content' block in your Drupal nodes
-author: Jeff Geerling
+author: geerlingguy
 nid: 352
 comments: true
 redirect_from: /blog/oscatholic/embedding-related-conten/

--- a/_posts/2010-11-17-google-refine-2-0.md
+++ b/_posts/2010-11-17-google-refine-2-0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google Refine 2.0
-author: Matt K
+author: matt-k
 nid: 355
 comments: true
 redirect_from: /forum/topics/355/

--- a/_posts/2010-11-24-online-calendaring-fullcalendar-js.md
+++ b/_posts/2010-11-24-online-calendaring-fullcalendar-js.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Online Calendaring: FullCalendar.js'
-author: Jeff Geerling
+author: geerlingguy
 nid: 357
 comments: true
 redirect_from: /blog/oscatholic/online-calendaring-fullc/

--- a/_posts/2010-12-15-mobile-device-usage-on-different-websites.md
+++ b/_posts/2010-12-15-mobile-device-usage-on-different-websites.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mobile Device Usage on Different Websites
-author: Jeff Geerling
+author: geerlingguy
 nid: 359
 comments: true
 redirect_from: /blog/oscatholic/mobile-device-usage-diff/

--- a/_posts/2010-12-15-new-minimalist-theme-released-for-drupal-7-mm.md
+++ b/_posts/2010-12-15-new-minimalist-theme-released-for-drupal-7-mm.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New minimalist theme released for Drupal 7 - MM
-author: Jeff Geerling
+author: geerlingguy
 nid: 358
 comments: true
 redirect_from: /blog/oscatholic/new-minimalist-theme-rel/

--- a/_posts/2010-12-27-crm-donation-reception-online-payments.md
+++ b/_posts/2010-12-27-crm-donation-reception-online-payments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CRM, Donation Reception, Online Payments
-author: Jeff Geerling
+author: geerlingguy
 nid: 361
 comments: true
 redirect_from: /wiki/117/crm-donation-reception-on/

--- a/_posts/2011-01-03-web-presence-social-media-internet-advertising-introduction.md
+++ b/_posts/2011-01-03-web-presence-social-media-internet-advertising-introduction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Web presence, Social media, Internet Advertising Introduction
-author: Mark Skender
+author: mark-skender
 nid: 363
 comments: true
 redirect_from: /blog/mark-skender/web-presence-social-me/

--- a/_posts/2011-01-05-drupal-7-released-have-you-tried-drupal-lately.md
+++ b/_posts/2011-01-05-drupal-7-released-have-you-tried-drupal-lately.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drupal 7 Released - Have You Tried Drupal Lately?
-author: Jeff Geerling
+author: geerlingguy
 nid: 364
 comments: true
 redirect_from: /blog/oscatholic/drupal-7-released-have-y/

--- a/_posts/2011-01-10-catholic-calendar-as-first-app-in-lifestyle-category-on-mac-app-store.md
+++ b/_posts/2011-01-10-catholic-calendar-as-first-app-in-lifestyle-category-on-mac-app-store.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Calendar as First App in 'Lifestyle' Category on Mac App Store
-author: Jeff Geerling
+author: geerlingguy
 nid: 365
 comments: true
 redirect_from: /blog/oscatholic/catholic-calendar-first-/

--- a/_posts/2011-01-24-pope-benedicts-message-for-45th-world-communications-day.md
+++ b/_posts/2011-01-24-pope-benedicts-message-for-45th-world-communications-day.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pope Benedict's Message for 45th World Communications Day
-author: Jeff Geerling
+author: geerlingguy
 nid: 366
 comments: true
 redirect_from: /blog/jeff-geerling/pope-benedicts-messag/

--- a/_posts/2011-01-26-the-apps-of-the-apostles-gadgets-for-god.md
+++ b/_posts/2011-01-26-the-apps-of-the-apostles-gadgets-for-god.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '"The Apps of the Apostles" - Gadgets for God'
-author: Jeff Geerling
+author: geerlingguy
 nid: 367
 comments: true
 redirect_from: /blog/oscatholic/apps-apostles-gadgets-go/

--- a/_posts/2011-01-30-openid-disabled-for-osc-site-login.md
+++ b/_posts/2011-01-30-openid-disabled-for-osc-site-login.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OpenID Disabled for OSC Site Login
-author: Jeff Geerling
+author: geerlingguy
 nid: 368
 comments: true
 redirect_from: /blog/oscatholic/openid-disabled-osc-site/

--- a/_posts/2011-02-03-beautiful-easy-maps-in-drupal-using-views-and-mapstraction.md
+++ b/_posts/2011-02-03-beautiful-easy-maps-in-drupal-using-views-and-mapstraction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Beautiful, Easy Maps in Drupal using Views and Mapstraction
-author: Jeff Geerling
+author: geerlingguy
 nid: 370
 comments: true
 redirect_from: /blog/oscatholic/beautiful-easy-maps-drup/

--- a/_posts/2011-02-08-communications-issues-the-catholic-churchs-confession-app.md
+++ b/_posts/2011-02-08-communications-issues-the-catholic-churchs-confession-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Communications Issues - The Catholic Church's "Confession" App
-author: Jeff Geerling
+author: geerlingguy
 nid: 371
 comments: true
 redirect_from: /blog/jeff-geerling/communications-snafu-/

--- a/_posts/2011-02-09-mobile-app-development.md
+++ b/_posts/2011-02-09-mobile-app-development.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mobile App Development?
-author: Jeff Geerling
+author: geerlingguy
 nid: 372
 comments: true
 redirect_from: /forum/topics/372/

--- a/_posts/2011-02-10-mass-and-sacrament-times-on-the-archdiocese-of-st-louis-website.md
+++ b/_posts/2011-02-10-mass-and-sacrament-times-on-the-archdiocese-of-st-louis-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mass and Sacrament Times on the Archdiocese of St. Louis' Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 373
 comments: true
 redirect_from: /blog/oscatholic/mass-and-sacrament-times/

--- a/_posts/2011-03-04-archdiocese-of-st-louis-new-iphone-app.md
+++ b/_posts/2011-03-04-archdiocese-of-st-louis-new-iphone-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Archdiocese of St. Louis' New iPhone App
-author: Jeff Geerling
+author: geerlingguy
 nid: 375
 comments: true
 redirect_from: /blog/jeff-geerling/archdiocese-st-louis-/

--- a/_posts/2011-03-08-creative-marketing-by-microsoft-at-drupalcon-chicago.md
+++ b/_posts/2011-03-08-creative-marketing-by-microsoft-at-drupalcon-chicago.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Creative Marketing by Microsoft at DrupalCon Chicago
-author: Jeff Geerling
+author: geerlingguy
 nid: 377
 comments: true
 redirect_from: /blog/oscatholic/creative-marketing-micro/

--- a/_posts/2011-03-17-catholic-news-live-simple-iphone-app-for-catholic-news.md
+++ b/_posts/2011-03-17-catholic-news-live-simple-iphone-app-for-catholic-news.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic News Live - Simple iPhone App for Catholic News
-author: Jeff Geerling
+author: geerlingguy
 nid: 378
 comments: true
 redirect_from: /blog/oscatholic/catholic-news-live-simpl/

--- a/_posts/2011-04-12-college-students-addicted-to-media.md
+++ b/_posts/2011-04-12-college-students-addicted-to-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: College Students - Addicted to Media
-author: Jeff Geerling
+author: geerlingguy
 nid: 380
 comments: true
 redirect_from: /blog/jeff-geerling/college-students-addi/

--- a/_posts/2011-05-03-bloggers-summit-at-the-vatican.md
+++ b/_posts/2011-05-03-bloggers-summit-at-the-vatican.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bloggers' Summit at the Vatican
-author: Jeff Geerling
+author: geerlingguy
 nid: 381
 comments: true
 redirect_from: /blog/oscatholic/bloggers-summit-vatican/

--- a/_posts/2011-05-25-archdiocese-of-st-louis-eucharistic-congress-website.md
+++ b/_posts/2011-05-25-archdiocese-of-st-louis-eucharistic-congress-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Archdiocese of St. Louis' Eucharistic Congress Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 383
 comments: true
 redirect_from: /blog/jeff-geerling/archdiocese-st-loui-0/

--- a/_posts/2011-05-25-catholic-tech-talks-5-best-diocesan-websites.md
+++ b/_posts/2011-05-25-catholic-tech-talks-5-best-diocesan-websites.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Tech Talk's 5 Best Diocesan Websites
-author: Jeff Geerling
+author: geerlingguy
 nid: 382
 comments: true
 redirect_from: /blog/jeff-geerling/catholic-tech-talks-5/

--- a/_posts/2011-06-16-google-maps-question.md
+++ b/_posts/2011-06-16-google-maps-question.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google Maps Question
-author: Cade_One
+author: cade-one
 nid: 385
 comments: true
 redirect_from: /forum/topics/385/

--- a/_posts/2011-06-27-new-mobile-apps-section-added-to-wiki.md
+++ b/_posts/2011-06-27-new-mobile-apps-section-added-to-wiki.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New 'Mobile Apps' Section added to Wiki
-author: Jeff Geerling
+author: geerlingguy
 nid: 391
 comments: true
 redirect_from: /blog/jeff-geerling/new-mobile-apps-secti/

--- a/_posts/2011-06-27-online-mobile-catholic-apps.md
+++ b/_posts/2011-06-27-online-mobile-catholic-apps.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Online / Mobile Catholic Apps
-author: Jeff Geerling
+author: geerlingguy
 nid: 387
 comments: true
 redirect_from: /wiki/117/online-mobile-catholic-ap/

--- a/_posts/2011-06-28-pope-benedict-tweets-the-launch-of-news-va.md
+++ b/_posts/2011-06-28-pope-benedict-tweets-the-launch-of-news-va.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pope Benedict Tweets the Launch of News.va
-author: Jeff Geerling
+author: geerlingguy
 nid: 392
 comments: true
 redirect_from: /blog/jeff-geerling/pope-benedict-tweets-/

--- a/_posts/2011-07-07-code-snippets-and-programming-resources.md
+++ b/_posts/2011-07-07-code-snippets-and-programming-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Code Snippets and Programming Resources
-author: Jeff Geerling
+author: geerlingguy
 nid: 393
 comments: true
 redirect_from: /wiki/117/code-snippets-and-program/

--- a/_posts/2011-07-07-php-array-list-of-all-united-states-dioceses.md
+++ b/_posts/2011-07-07-php-array-list-of-all-united-states-dioceses.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: PHP Array (List) of All United States Dioceses
-author: Jeff Geerling
+author: geerlingguy
 nid: 394
 comments: true
 redirect_from: /wiki/117/php-array-list-all-united/

--- a/_posts/2011-08-26-is-apple-catholic.md
+++ b/_posts/2011-08-26-is-apple-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "'Is Apple Catholic?'"
-author: Jeff Geerling
+author: geerlingguy
 nid: 400
 comments: true
 redirect_from: /blog/jeff-geerling/apple-catholic/

--- a/_posts/2011-09-05-good-to-read-again-hallmarks-of-a-great-developer.md
+++ b/_posts/2011-09-05-good-to-read-again-hallmarks-of-a-great-developer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Good to Read Again: Hallmarks of a Great Developer'
-author: Jeff Geerling
+author: geerlingguy
 nid: 401
 comments: true
 redirect_from: /blog/jeff-geerling/good-read-again-hallm/

--- a/_posts/2011-09-21-calling-mobile-developers.md
+++ b/_posts/2011-09-21-calling-mobile-developers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Calling Mobile Developers
-author: Jeff Geerling
+author: geerlingguy
 nid: 402
 comments: true
 redirect_from: /blog/jeff-geerling/calling-mobile-develo/

--- a/_posts/2011-09-30-mobile-app-development-resources.md
+++ b/_posts/2011-09-30-mobile-app-development-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mobile App Development Resources
-author: Jeff Geerling
+author: geerlingguy
 nid: 403
 comments: true
 redirect_from: /wiki/117/mobile-app-development-re/

--- a/_posts/2011-10-08-private-social-networks-for-parishes.md
+++ b/_posts/2011-10-08-private-social-networks-for-parishes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Private Social Networks for Parishes
-author: Jeff Geerling
+author: geerlingguy
 nid: 404
 comments: true
 redirect_from: /blog/jeff-geerling/private-social-networ/

--- a/_posts/2011-10-17-catholic-diocese-app.md
+++ b/_posts/2011-10-17-catholic-diocese-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Diocese App
-author: Jeff Geerling
+author: geerlingguy
 nid: 407
 comments: true
 redirect_from: /project/catholic-diocese-app/

--- a/_posts/2011-10-24-open-parish-initiative.md
+++ b/_posts/2011-10-24-open-parish-initiative.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Parish Initiative
-author: Jeff Geerling
+author: geerlingguy
 nid: 409
 comments: true
 redirect_from: /project/open-parish/

--- a/_posts/2011-11-02-onebillionstories-com-seeks-intern-for-web-development.md
+++ b/_posts/2011-11-02-onebillionstories-com-seeks-intern-for-web-development.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: OneBillionStories.com seeks Intern for Web Development
-author: OneBillionStories.com
+author: onebillionstories-com
 nid: 410
 comments: true
 redirect_from: /forum/topics/410/

--- a/_posts/2011-11-06-preventing-form-spam-on-your-website.md
+++ b/_posts/2011-11-06-preventing-form-spam-on-your-website.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Preventing Form Spam on Your Website
-author: Jeff Geerling
+author: geerlingguy
 nid: 411
 comments: true
 redirect_from: /blog/jeff-geerling/preventing-form-spam-/

--- a/_posts/2011-11-23-the-catholic-developer-and-blogger-christmas-wish-list-2011.md
+++ b/_posts/2011-11-23-the-catholic-developer-and-blogger-christmas-wish-list-2011.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Catholic Developer and Blogger Christmas Wish List - 2011
-author: Jeff Geerling
+author: geerlingguy
 nid: 412
 comments: true
 redirect_from: /blog/jeff-geerling/catholic-developers-c/

--- a/_posts/2011-12-05-website-minimalism.md
+++ b/_posts/2011-12-05-website-minimalism.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Website Minimalism
-author: Jeff Geerling
+author: geerlingguy
 nid: 413
 comments: true
 redirect_from: /blog/jeff-geerling/website-minimalism/

--- a/_posts/2011-12-15-archdiocese-of-saint-louis-redesigns-website-still-running-drupal.md
+++ b/_posts/2011-12-15-archdiocese-of-saint-louis-redesigns-website-still-running-drupal.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Archdiocese of Saint Louis redesigns website (still running Drupal)
-author: Jeff Geerling
+author: geerlingguy
 nid: 416
 comments: true
 redirect_from: /blog/jeff-geerling/archdiocese-saint-lou/

--- a/_posts/2011-12-27-open-access-to-the-catholic-bible-and-catechism-nab-nabre-and-ccc.md
+++ b/_posts/2011-12-27-open-access-to-the-catholic-bible-and-catechism-nab-nabre-and-ccc.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Access to the Catholic Bible and Catechism (NAB/NABRE and CCC)
-author: Jeff Geerling
+author: geerlingguy
 nid: 417
 comments: true
 redirect_from: /blog/jeff-geerling/open-access-catholic/

--- a/_posts/2011-12-28-xml-format-for-parish-directory-information.md
+++ b/_posts/2011-12-28-xml-format-for-parish-directory-information.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: XML Format for Parish Directory Information
-author: Jeff Geerling
+author: geerlingguy
 nid: 419
 comments: true
 redirect_from: /wiki/117/xml-format-parish-directo/

--- a/_posts/2012-05-23-catholic-tech-summit-at-cnmc-2012-aug-29.md
+++ b/_posts/2012-05-23-catholic-tech-summit-at-cnmc-2012-aug-29.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Tech Summit at CNMC 2012, Aug 29
-author: Jeff Geerling
+author: geerlingguy
 nid: 422
 comments: true
 redirect_from: /blog/jeff-geerling/catholic-tech-summit-/

--- a/_posts/2012-06-05-the-importance-of-mobile-for-the-church.md
+++ b/_posts/2012-06-05-the-importance-of-mobile-for-the-church.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Importance of Mobile for the Church
-author: Jeff Geerling
+author: geerlingguy
 nid: 421
 comments: true
 redirect_from: /blog/jeff-geerling/importance-mobile-chu/

--- a/_posts/2012-06-11-cathnet-wiki.md
+++ b/_posts/2012-06-11-cathnet-wiki.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cathnet Wiki
-author: Jeff Geerling
+author: geerlingguy
 nid: 433
 comments: true
 redirect_from: /wiki/433/cathnet-wiki/

--- a/_posts/2012-06-11-site-reorganization-oscatholic-irc-channel-decommissioned.md
+++ b/_posts/2012-06-11-site-reorganization-oscatholic-irc-channel-decommissioned.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Site Reorganization, #oscatholic IRC channel decommissioned'
-author: Jeff Geerling
+author: geerlingguy
 nid: 434
 comments: true
 redirect_from: /blog/jeff-geerling/site-reorganization-o/

--- a/_posts/2012-06-13-vatican-applies-for-four-gtlds.md
+++ b/_posts/2012-06-13-vatican-applies-for-four-gtlds.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vatican Applies for Four gTLDs
-author: Jeff Geerling
+author: geerlingguy
 nid: 436
 comments: true
 redirect_from: /blog/jeff-geerling/vatican-applies-four-/

--- a/_posts/2012-06-14-usccb-announces-browser-based-ebook-catechism.md
+++ b/_posts/2012-06-14-usccb-announces-browser-based-ebook-catechism.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: USCCB Announces 'Browser-Based eBook' Catechism
-author: Jeff Geerling
+author: geerlingguy
 nid: 437
 comments: true
 redirect_from: /blog/jeff-geerling/usccb-announces-brows/

--- a/_posts/2012-06-19-beta-test-period-for-catechism-api-25-keys-available.md
+++ b/_posts/2012-06-19-beta-test-period-for-catechism-api-25-keys-available.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Beta test period for Catechism API - 25 keys available
-author: Jeffrey Pinyan - Praying the Mass
+author: jeffrey-pinyan-praying-the-mass
 nid: 438
 comments: true
 redirect_from: /blog/jeffrey-pinyan-praying-ma/beta-test/

--- a/_posts/2012-06-29-the-distraction-caused-by-mobile-in-church.md
+++ b/_posts/2012-06-29-the-distraction-caused-by-mobile-in-church.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The distraction caused by Mobile in Church
-author: Youshaa
+author: youshaa
 nid: 440
 comments: true
 redirect_from: /blog/youshaa/youth-should-not-bring-mo/

--- a/_posts/2012-06-30-catholic-diocese-app-for-ios-android-powers-new-jesuit-app.md
+++ b/_posts/2012-06-30-catholic-diocese-app-for-ios-android-powers-new-jesuit-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Diocese App for iOS/Android powers new Jesuit App
-author: Jeff Geerling
+author: geerlingguy
 nid: 441
 comments: true
 redirect_from: /blog/jeff-geerling/catholic-diocese-app/

--- a/_posts/2012-07-12-catholic-new-media-job-opportunities.md
+++ b/_posts/2012-07-12-catholic-new-media-job-opportunities.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic/New Media Job Opportunities
-author: Jeff Geerling
+author: geerlingguy
 nid: 442
 comments: true
 redirect_from: /blog/jeff-geerling/catholicnew-media-job/

--- a/_posts/2012-08-15-another-catholic-job-opportunity-ecatholic.md
+++ b/_posts/2012-08-15-another-catholic-job-opportunity-ecatholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Another Catholic Job Opportunity: eCatholic'
-author: Jeff Geerling
+author: geerlingguy
 nid: 443
 comments: true
 redirect_from: /blog/jeff-geerling/another-catholic-job-/

--- a/_posts/2012-08-15-new-jobs-in-support-and-social-media.md
+++ b/_posts/2012-08-15-new-jobs-in-support-and-social-media.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New Jobs in support and social media
-author: Jeff Geerling
+author: geerlingguy
 nid: 444
 comments: true
 redirect_from: /forum/topics/444/

--- a/_posts/2012-08-22-iphone-a-powerful-tool-for-the-new-evangelization.md
+++ b/_posts/2012-08-22-iphone-a-powerful-tool-for-the-new-evangelization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: iPhone - A Powerful tool for the New Evangelization
-author: Jeff Geerling
+author: geerlingguy
 nid: 446
 comments: true
 redirect_from: /blog/jeff-geerling/iphone-powerful-tool/

--- a/_posts/2012-08-22-open-source-catholic-upgraded-to-drupal-7.md
+++ b/_posts/2012-08-22-open-source-catholic-upgraded-to-drupal-7.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic Upgraded to Drupal 7
-author: Jeff Geerling
+author: geerlingguy
 nid: 445
 comments: true
 redirect_from: /blog/jeff-geerling/open-source-catholic/

--- a/_posts/2012-08-26-catholic-mobile-app-directories.md
+++ b/_posts/2012-08-26-catholic-mobile-app-directories.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Mobile App Directories
-author: Jeff Geerling
+author: geerlingguy
 nid: 447
 comments: true
 redirect_from: /wiki/catholic-mobile-app/catholic-mobile/

--- a/_posts/2012-08-29-cnmc-2012-tech-summit.md
+++ b/_posts/2012-08-29-cnmc-2012-tech-summit.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CNMC 2012 - Tech Summit
-author: Jeff Geerling
+author: geerlingguy
 nid: 448
 comments: true
 redirect_from: /blog/jeff-geerling/cnmc-2012-tech-summit/

--- a/_posts/2012-09-03-an-app-for-every-diocese.md
+++ b/_posts/2012-09-03-an-app-for-every-diocese.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: An App for Every Diocese
-author: Jeff Geerling
+author: geerlingguy
 nid: 450
 comments: true
 redirect_from: /blog/jeff-geerling/app-every-diocese/

--- a/_posts/2012-09-08-fantasy-league-platform-w-catholic-bent.md
+++ b/_posts/2012-09-08-fantasy-league-platform-w-catholic-bent.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fantasy League Platform w/Catholic Bent
-author: JMGrenda
+author: jmgrenda
 nid: 451
 comments: true
 redirect_from: /forum/topics/451/

--- a/_posts/2012-09-12-catholic-diocese-app-developers.md
+++ b/_posts/2012-09-12-catholic-diocese-app-developers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Catholic Diocese App Developers
-author: Jeff Geerling
+author: geerlingguy
 nid: 452
 comments: true
 redirect_from: /wiki/catholic-diocese-app/catholic/

--- a/_posts/2012-09-25-a-faster-drupala-faster-web.md
+++ b/_posts/2012-09-25-a-faster-drupala-faster-web.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: A Faster Drupal—a Faster Web
-author: Jeff Geerling
+author: geerlingguy
 nid: 454
 comments: true
 redirect_from: /blog/jeff-geerling/faster-drupal-faster-web/

--- a/_posts/2012-09-25-developer-wanted.md
+++ b/_posts/2012-09-25-developer-wanted.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Developer Wanted
-author: Petros Media
+author: petros-media
 nid: 455
 comments: true
 redirect_from: /forum/topics/455/

--- a/_posts/2012-10-02-2013-world-communications-day-theme-social-networks.md
+++ b/_posts/2012-10-02-2013-world-communications-day-theme-social-networks.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '2013 World Communications Day Theme: Social Networks'
-author: Jeff Geerling
+author: geerlingguy
 nid: 456
 comments: true
 redirect_from: /blog/jeff-geerling/2013-world/

--- a/_posts/2012-11-29-the-pope-on-twitter.md
+++ b/_posts/2012-11-29-the-pope-on-twitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Pope, on Twitter
-author: Jeff Geerling
+author: geerlingguy
 nid: 459
 comments: true
 redirect_from: /blog/jeff-geerling/pope-twitter/

--- a/_posts/2012-12-04-strange-requests-for-translations-from-webhostinggeeks.md
+++ b/_posts/2012-12-04-strange-requests-for-translations-from-webhostinggeeks.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Strange requests for translations from WebHostingGeeks
-author: Jeff Geerling
+author: geerlingguy
 nid: 460
 comments: true
 redirect_from: /blog/jeff-geerling/strange-requests/

--- a/_posts/2012-12-12-the-popes-first-tweet-pontifex.md
+++ b/_posts/2012-12-12-the-popes-first-tweet-pontifex.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Pope's first tweet (@pontifex)
-author: Jeff Geerling
+author: geerlingguy
 nid: 461
 comments: true
 redirect_from: /blog/jeff-geerling/popes-first-tweet/

--- a/_posts/2013-01-24-2013-world-communications-day-social-networks.md
+++ b/_posts/2013-01-24-2013-world-communications-day-social-networks.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: '2013 World Communications Day: Social Networks'
-author: Jeff Geerling
+author: geerlingguy
 nid: 464
 comments: true
 redirect_from: /blog/jeff-geerling/2013-world-0/

--- a/_posts/2013-02-17-boodroo.md
+++ b/_posts/2013-02-17-boodroo.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: BooDroo
-author: JohnFitzgerald
+author: johnfitzgerald
 nid: 465
 comments: true
 redirect_from: /blog/john-fitzgerald/boodroo/

--- a/_posts/2013-02-25-thankspontifex-a-twitter-storm-to-thank-the-pope.md
+++ b/_posts/2013-02-25-thankspontifex-a-twitter-storm-to-thank-the-pope.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "#ThanksPontifex - a Twitter Storm to Thank the Pope"
-author: MPSchneiderLC
+author: mpschneiderlc
 nid: 466
 comments: true
 redirect_from: /blog/br-matthew-p-schneider-lc-0/

--- a/_posts/2013-06-04-how-to-setup-lamp-in-ubuntu.md
+++ b/_posts/2013-06-04-how-to-setup-lamp-in-ubuntu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to setup LAMP in Ubuntu
-author: JoaoMachado
+author: joaomachado
 nid: 471
 comments: true
 redirect_from: /blog/joao-john-machado/how-setup-lamp/

--- a/_posts/2013-06-17-my-confessor-app-service-know-when-your-priest-is-hearing-confessions.md
+++ b/_posts/2013-06-17-my-confessor-app-service-know-when-your-priest-is-hearing-confessions.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: My Confessor app/service - know when your priest is hearing confessions
-author: Jeff Geerling
+author: geerlingguy
 nid: 472
 comments: true
 redirect_from: /blog/jeff-geerling/my-confessor/

--- a/_posts/2013-06-18-developing-a-drupal-solution-for-a-diocese-e-learning-crm-event-management-integrated-parish-sites.md
+++ b/_posts/2013-06-18-developing-a-drupal-solution-for-a-diocese-e-learning-crm-event-management-integrated-parish-sites.md
@@ -2,7 +2,7 @@
 layout: post
 title: Developing a Drupal solution for a Diocese (+ e-learning, crm, event management,
   integrated parish sites)
-author: jonathan.henderson
+author: jonathan-henderson
 nid: 473
 comments: true
 redirect_from: /forum/topics/473/

--- a/_posts/2013-06-29-commenting-now-requires-registration.md
+++ b/_posts/2013-06-29-commenting-now-requires-registration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Commenting now requires registration
-author: Jeff Geerling
+author: geerlingguy
 nid: 474
 comments: true
 redirect_from: /forum/topics/474/

--- a/_posts/2013-07-12-free-the-word-allowing-access-to-evangelical-church-texts.md
+++ b/_posts/2013-07-12-free-the-word-allowing-access-to-evangelical-church-texts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Free the Word - Allowing Access to Evangelical Church Texts
-author: Jeff Geerling
+author: geerlingguy
 nid: 475
 comments: true
 redirect_from: /blog/jeff-geerling/free-word-allowing/

--- a/_posts/2013-07-23-video-the-legacy-of-pope-benedict-xvi.md
+++ b/_posts/2013-07-23-video-the-legacy-of-pope-benedict-xvi.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Video: The Legacy of Pope Benedict XVI'
-author: JohnFitzgerald
+author: johnfitzgerald
 nid: 476
 comments: true
 redirect_from: /blog/john-fitzgerald/video-legacy-pope/

--- a/_posts/2013-08-06-video-proving-the-existence-of-god.md
+++ b/_posts/2013-08-06-video-proving-the-existence-of-god.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Video: Proving the Existence of God'
-author: JohnFitzgerald
+author: johnfitzgerald
 nid: 477
 comments: true
 redirect_from: /blog/john-fitzgerald/video-proving/

--- a/_posts/2013-10-09-are-you-setting-up-your-parish-websites-for-failure.md
+++ b/_posts/2013-10-09-are-you-setting-up-your-parish-websites-for-failure.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Are you setting up your parish websites for failure?
-author: Jeff Geerling
+author: geerlingguy
 nid: 480
 comments: true
 redirect_from: /blog/jeff-geerling/are-you-setting-your/

--- a/_posts/2014-07-25-church-io-onebody-directory-and-social-networking-software.md
+++ b/_posts/2014-07-25-church-io-onebody-directory-and-social-networking-software.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Church.io OneBody directory and social networking software
-author: Jeff Geerling
+author: geerlingguy
 nid: 485
 comments: true
 redirect_from: /blog/jeff-geerling/churchio-onebody/

--- a/_posts/2015-02-03-the-future-of-open-source-catholic.md
+++ b/_posts/2015-02-03-the-future-of-open-source-catholic.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Future of Open Source Catholic
-author: Jeff Geerling
+author: geerlingguy
 nid: 486
 comments: true
 redirect_from: /blog/jeff-geerling/future-open-source/

--- a/_posts/2015-04-30-5-things-every-parish-website-should-have-in-2015.md
+++ b/_posts/2015-04-30-5-things-every-parish-website-should-have-in-2015.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 5 Things Every Parish Website Should Have in 2015
-author: Nobis Media
+author: nobis-media
 nid: 487
 comments: true
 redirect_from: /blog/conoon-kim/5-things-every-parish/

--- a/_posts/2015-05-09-open-source-is-only-reliable-way-to-preserve-human-history-argues-vatican.md
+++ b/_posts/2015-05-09-open-source-is-only-reliable-way-to-preserve-human-history-argues-vatican.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open source is 'only reliable way' to preserve human history, argues Vatican
-author: Jeff Geerling
+author: geerlingguy
 nid: 488
 comments: true
 redirect_from: /blog/jeff-geerling/open-source-only/

--- a/_posts/2015-12-28-open-source-catholic-moving-towards-a-more-open-site.md
+++ b/_posts/2015-12-28-open-source-catholic-moving-towards-a-more-open-site.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Source Catholic - moving towards a more open site
-author: Jeff Geerling
+author: geerlingguy
 nid: 489
 redirect_from: /blog/jeff-geerling/open-source-catholic-future-github/
 created: 1451333151

--- a/_posts/2016-01-05-migration-to-jekyll.md
+++ b/_posts/2016-01-05-migration-to-jekyll.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Migration to Jekyll and GitHub Pages from Drupal site"
 date:   2016-01-05 22:44:58 -0500
 categories: jekyll update github pages drupal migrate
-author: Jeff Geerling
+author: geerlingguy
 comments: true
 ---
 <img src="/images/jekyll-github-pages.png" alt="Jekyll and GitHub Pages" class="center-image" width="600" height="230" />

--- a/scripts/create_authors.rb
+++ b/scripts/create_authors.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+def slugify(text)
+    text = text.gsub(/'/, "")
+    text = text.gsub(/[^a-zA-Z0-9]/, "-")
+    text = text.gsub(/-+/, "-")
+    if text.start_with?("-")
+        text = text [1..-1]
+    end
+    if text.end_with?("-")
+        text = text[0..-2]
+    end
+    return text.downcase
+end
+
+authors = {}
+
+Dir.glob('../_posts/*.md') do |filename|
+    puts filename
+    
+    frontmatter = YAML.load_file(filename)
+    name = frontmatter['author']
+    author = slugify(name)
+    authors[author] = name
+    
+    post = File.read(filename)
+    File.open(filename, 'w') do |f|
+        f.puts(post.gsub(/author:.*$/, "author: #{author}"))
+    end
+end
+
+File.open('authors.yml', 'w') do |f|
+    authors.sort.each do |author, name|
+        f.puts("#{author}:")
+        f.puts("  name: #{name}")
+    end
+end
+


### PR DESCRIPTION
This commit is the first step for #9.

The idea is to add each author to `_config.yml` with a key for their
name. In the future, we can add additional (perhaps optional) keys for
GitHub, Twitter, email, etc. We can then update the post layout to use
whatever of these keys are available. When the author creates a post,
their info only needs to be in `_config.yml` once. As long as the post
references their author key, it can pull the info it needs.

To get this rolling, I've generated a "key"(username?) for each author
by downcasing their name and replacing spaces with `-`. These can be
adjusted for authors' preferences in the future, but I needed something
to start with. All authors have a `name` right now, but that's currently
the only field. (We should plan on supporting others.)

All this was done primarily with a script, which I've included in a new
`scripts` directory. (It seemed prudent to save stuff like this, though
it's also fine with me if we'd prefer to discard it.) The script makes
the changes to each post and spits out a yml file with authors. Then I
did one or two manual touch-ups and put the authors in `_config.yml`.

With this commit, the site remains in a working state, with no visible
changes. Although we've moved some "config" around, the posts themselves
still display the author name, exactly as they did before.