### PR TITLE
Add CatholicDevs Slack Links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,6 +25,10 @@
             {% include icon-twitter.html username=site.twitter_username %}
           </li>
           {% endif %}
+
+          <li>
+            {% include icon-slack.html %}
+          </li>
         </ul>
       </div>
 

--- a/_includes/icon-slack.html
+++ b/_includes/icon-slack.html
@@ -1,0 +1,1 @@
+<a href="https://catholicdevs.slack.com"><i class="fab fa-slack"></i> <span class="username">catholicdevs</span></a>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -273,3 +273,21 @@
 .category-label {
   font-style: italic;
 }
+
+
+/**
+ * Slack Invitation
+ */
+.slack-invitation {
+    height: 250px;
+    width: 300px;
+    margin-top: 2rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+.slack-help-link {
+    width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2rem;
+}

--- a/chat.md
+++ b/chat.md
@@ -1,9 +1,33 @@
 ---
 layout: page
-title: "IRC"
-permalink: /irc/
-redirect_from: /catholic-irc-chat-channel/
+title: "Chat"
+permalink: /chat/
+redirect_from:
+  - /irc/
+  - /catholic-irc-chat-channel/
 ---
+
+**We're building a community of Catholic developers.** Come join us! You can find us on Slack and on IRC.
+
+## Slack
+
+The [CatholicDevs Slack Workspace](<a href="https://catholicdevs.slack.com"><i class="fab fa-slack"></i> <span class="username">catholicdevs</span></a>
+) is a place to engage with other Catholic developers across the globe and grow together by getting to know each other, sharing our faith, and collaborating on projects.
+
+To join CatholicDevs on Slack, you must request an invitation.
+
+
+
+<div class="slack-invitation">
+  <div id="CommunityInviter"></div>
+</div>
+<div class="slack-help-link">
+  <a href="https://slack.com/help/articles/115004071768-What-is-Slack-">What is Slack?</a>
+</div>
+
+
+## IRC
+
 Below, you can login to the public Catholic chat channel on the Freenode's IRC (Internet Relay Chat) system. Simply type in a nickname and click the "Connect" button.
 
 Scroll down for more details, and to find out other ways to connect.
@@ -32,3 +56,21 @@ There are many ways to join a channel in IRC:
 **Changing Names**: if you'd like to change your username (say, to inform someone you're on the channel, but need to run for a minute), type in `/nick new_username` (example: if you're running to lunch, type in `/nick username_lunch`).
 
 **Directed Messages**: To 'ping' someone inside the channel, simply type in his username and hit enter, or add his username anywhere in your message. Bonus shortcut: just type in the first couple letters of a username and press tab - the program will fill in the rest of the username!
+
+
+<script>
+  window.CommunityInviterAsyncInit = function () {
+    CommunityInviter.init({
+      app_url:'open-source-catholic',
+      team_id:'catholicdevs'
+   })
+  };
+
+  (function(d, s, id){
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) {return;}
+    js = d.createElement(s); js.id = id;
+    js.src = "https://communityinviter.com/js/communityinviter.js";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'Community_Inviter'));
+</script>


### PR DESCRIPTION
This commit changes the "IRC" page to a "Chat" page. We're still linking
to the `##catholic` channel on Freenode, but we're now also linking to
the CatholicDevs Slack workspace that John's been building.

In addition, I added a link to the Slack workspace as a social icon in
our footer.

There's no way to allow new users to join a Slack workspace without an
invitation. To work around this, we're using
https://communityinviter.com to provide automatic Slack invitations to
anyone who requests one from this site. I don't expect an overwhelming
volume here, but we can flip a switch to require approval of these
invitations at any time using Community Inviter.

Fixes #30