### PR TITLE
Migrate Deployment to GitHub Actions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,29 @@
+# GitHub Action for Jekyll
+#
+# Runs jekyll build on master and pushes output to gh-pages branch.
+# (Then GitHub deploys that static content.)
+
+name: Build & Deploy Jekyll to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-latest
+    container: ruby:2.7.1-buster
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+      - run: bundle install
+      - run: bundle exec jekyll build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   github-pages:
     runs-on: ubuntu-latest
-    container: ruby:2.7.1-buster
+    container: ruby:2-buster
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1


### PR DESCRIPTION
Our current deployment uses the traditional GitHub Pages Jekyll build.
That is, GitHub Pages performs the build for us and deploys the result.
The GitHub Pages Jekyll build process is a little bit restrictive. We're
limited to Jekyll 3.9 and we can't use plugins that aren't in the
[approved list](https://pages.github.com/versions/).

A newer approach to deploying a Jekyll site with GitHub Pages uses
GitHub Actions. A GitHub Action is GitHub's own solution to generic
CI/CD. Therefore, our GitHub Action can build any version of Jekyll with
any plugins. The action pushes the result of this build to the
`gh-pages` branch, and then we deploy that branch as a pre-built static
site on GitHub Pages.

After this commit is merged, the Action will run (creating the branch),
but we won't be publishing the new branch 'til we manually edit the
repository settings to deploy from `gh-pages` instead of `master`. (This
gives us time to verify the build worked, etc.)