### PR TITLE
Install gems to vendor/bundle during CI build

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Ruby dependencies.
         run: |
           gem install bundler
-          bundle install
+          bundle install --path vendor/bundle 
 
       - name: Build static site with Jekyll.
         run: bundle exec jekyll build


### PR DESCRIPTION
When we build the site using GitHub Actions, we should install gems to
vendor/bundler. We already have a build step to cache that directory to
save time on future builds.

Fixes #39