### PR TITLE
Fix broken link in about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -15,7 +15,7 @@ Our logo, which displays one of the keys to the Church (as seen on the Papal coa
 You can help this website by doing one of many things:
 
   1. Join the discussion on posts on the site.
-  2. Contribute new content to the site by following the [CONTRIBUTING](CONTRIBUTING.md) guide.
+  2. Contribute new content to the site by following the [CONTRIBUTING](https://github.com/opensourcecatholic/opensourcecatholic.github.io/blob/master/CONTRIBUTING.md) guide.
   3. Join public discussions in the [Open Source Catholic mailing list](https://groups.google.com/forum/#!forum/open-source-catholic).
   4. Pray for the Church (it works wonders!).
 


### PR DESCRIPTION
`about.md` contained a link to `CONTRIBUTING.md`. This link actually
worked when viewing `about.md` as a markdown file - `CONTRIBUTING.md` is
in the same directory so a relative link works fine. However, when
Jekyll builds the site, `about.md` turns into an HTML page at
`/about/index.html`, and the relative link to `CONTRIBUTING.md` breaks.
(Also, I don't think we're even publishing CONTRIBUTING.md to the web --
which is fine, since people can read it as markdown on GitHub.)

The fix is simple -- just link to
https://github.com/opensourcecatholic/opensourcecatholic.github.io/blob/master/CONTRIBUTING.md