### PR TITLE
Update actions/cache and Run Tests on PRs

### DIFF
--- a/.github/actions/jekyll-build/action.yml
+++ b/.github/actions/jekyll-build/action.yml
@@ -1,0 +1,21 @@
+name: Jekyll Build
+description: Installs Ruby gems and builds Jekyll site
+runs:
+  using: composite
+  steps:
+    - name: Cache Gem Dependencies
+      uses: actions/cache@v4
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock', '.ruby-version') }}
+
+    - name: Install Ruby Gems
+      shell: bash
+      run: |
+        gem install bundler
+        bundle config set path 'vendor/bundle'
+        bundle install 
+
+    - name: Jekyll Build
+      shell: bash
+      run: bundle exec jekyll build

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,18 +16,8 @@ jobs:
     container: ruby:3.2.2-bookworm
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
 
-      - name: Install Ruby dependencies.
-        run: |
-          gem install bundler
-          bundle install --path vendor/bundle 
-
-      - name: Build static site with Jekyll.
-        run: bundle exec jekyll build
+      - uses: ./.github/actions/jekyll-build
 
       - name: Deploy static site to gh-pages branch.
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+# GitHub Action for Jekyll
+#
+# Runs jekyll build on pull requests to verify that they build.
+
+name: Test Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: ruby:3.2.2-bookworm
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/jekyll-build


### PR DESCRIPTION
Our build and deploy workflow was using an outdated version of actions/cache that's no longer supported. That can be fixed by updating to actions/cache@v4. No interface changes are required in our YAML.

We also need a way to make sure this works before merging the PR (if we don't want to debug a workflow after merge). The simplest way to do this is to extract our jekyll build steps into a github action. We can write a simple test workflow that just does a jekyll build, and we can use the same jekyll-build action in our existing deploy workflow.