### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/actions/jekyll-build/action.yml
+++ b/.github/actions/jekyll-build/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Cache Gem Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock', '.ruby-version') }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     container: ruby:3.4
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/jekyll-build
 
       - name: Deploy static site to gh-pages branch.
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     container: ruby:3.4
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/jekyll-build


### PR DESCRIPTION
Update to actions/checkout@v6, peaceiris/actions-gh-pages@v4, and actions/cache@v5.

The main driving factor here is GitHub's deprecation of old NodeJS versions, which will soon make some of the versions we're currently using break.

> Node.js 20 actions are deprecated. The following actions are running
> on Node.js 20 and may not work as expected: actions/cache@v4,
> actions/checkout@v2. Actions will be forced to run with Node.js 24 by
> default starting June 2nd, 2026. Node.js 20 will be removed from the
> runner on September 16th, 2026. Please check if updated versions of
> these actions are available that support Node.js 24.